### PR TITLE
warnings.warn removed

### DIFF
--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -12,6 +12,7 @@ from types cimport Model, Delay, Propensity, Rule
 from scipy.integrate import odeint, ode
 import sys
 import warnings
+import logging
 
 
 ##################################################                ####################################################
@@ -266,7 +267,7 @@ cdef class CSimInterface:
 
     #Checks model or interface is valid. Meant to be overriden by the subclass
     cdef void check_interface(self):
-        warnings.warn("No interface Checking Implemented")
+        logging.info("No interface Checking Implemented")
     # meant to be overriden by the subclass
     cdef double compute_delay(self, double *state, unsigned rxn_index):
         return 0.0
@@ -418,7 +419,7 @@ cdef class ModelCSimInterface(CSimInterface):
         #Check Model and initialization
         if not self.model.initialized:
             self.model.py_initialize()
-            warnings.warn("Uninitialized Model Passed into ModelCSimInterface. Model.py_initialize() called automatically.")
+            logging.info("Uninitialized Model Passed into ModelCSimInterface. Model.py_initialize() called automatically.")
         self.check_interface()
         self.c_propensities = self.model.get_c_propensities()
         self.c_delays = self.model.get_c_delays()
@@ -1344,7 +1345,7 @@ cdef class DeterministicSimulator(RegularSimulator):
                         sim.apply_repeated_rules( &(results[index,0]),timepoints[index] )
                 return SSAResult(timepoints,results)
 
-            sys.stderr.write('odeint failed with mxstep=%d...' % (steps_allowed))
+            logging.info('odeint failed with mxstep=%d...' % (steps_allowed))
 
             # make the mxstep bigger if the user specified a bigger max
             if steps_allowed >= self.mxstep:
@@ -1418,7 +1419,7 @@ cdef class DeterministicDilutionSimulator(RegularSimulator):
                         sim.apply_repeated_rules( &(results[index,0]), timepoints[index] )
                 return SSAResult(timepoints,results)
 
-            sys.stderr.write('odeint failed with mxstep=%d...' % (steps_allowed))
+            logging.info('odeint failed with mxstep=%d...' % (steps_allowed))
 
             # make the mxstep bigger if the user specified a bigger max
             if steps_allowed >= self.mxstep:
@@ -2068,7 +2069,7 @@ def py_simulate_model(timepoints, Model = None, Interface = None, stochastic = F
         else:
             Interface = ModelCSimInterface(Model)
     elif not Interface is None and safe:
-        warnings.warn("Cannot gaurantee that the interface passed in is safe. Simulating anyway.")
+        logging.info("Cannot gaurantee that the interface passed in is safe. Simulating anyway.")
 
     #Create Volume (if necessary)
     if isinstance(volume, Volume):
@@ -2111,7 +2112,7 @@ def py_simulate_model(timepoints, Model = None, Interface = None, stochastic = F
             result = Sim.py_volume_simulate(Interface, v, timepoints)
     else:
         if v != None:
-            warnings.warn("uncessary volume parameter for deterministic simulation.")
+            logging.info("uncessary volume parameter for deterministic simulation.")
         Sim = DeterministicSimulator()
         Interface.py_prep_deterministic_simulation()
         result = Sim.py_simulate(Interface, timepoints)

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -11,6 +11,7 @@ import re
 import sympy
 from sympy.abc import _clash1
 import warnings
+import logging
 import libsbml
 from bioscrape.sbmlutil import add_species, add_parameter, add_reaction, add_rule, create_sbml_model, import_sbml
 
@@ -120,7 +121,7 @@ cdef class ConstitutivePropensity(Propensity):
             elif key == "propensity_type":
                 pass
             else:
-                warnings.warn('Warning! Useless field for ConstitutivePropensity'+str(key))
+                logging.info('Warning! Useless field for ConstitutivePropensity'+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([],[fields['k']])
@@ -148,7 +149,7 @@ cdef class UnimolecularPropensity(Propensity):
             elif key == "propensity_type":
                 pass
             else:
-                warnings.warn('Warning! Useless field for UnimolecularPropensity '+str(key))
+                logging.info('Warning! Useless field for UnimolecularPropensity '+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([ fields['species'] ],[ fields['k'] ])
@@ -193,7 +194,7 @@ cdef class BimolecularPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for BimolecularPropensity'+str(key))
+                logging.info('Warning! Useless field for BimolecularPropensity'+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([ x.strip() for x in fields['species'].split('*') ],[ fields['k'] ])
@@ -231,7 +232,7 @@ cdef class PositiveHillPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for PositiveHillPropensity '+str(key))
+                logging.info('Warning! Useless field for PositiveHillPropensity '+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([ fields['s1'] ],[ fields['K'],fields['n'],fields['k'] ])
@@ -274,7 +275,7 @@ cdef class PositiveProportionalHillPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for PositiveProportionalHillPropensity '+str(key))
+                logging.info('Warning! Useless field for PositiveProportionalHillPropensity '+str(key))
 
 
     def get_species_and_parameters(self, dict fields, **keywords):
@@ -314,7 +315,7 @@ cdef class NegativeHillPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for NegativeHillPropensity '+str(key))
+                logging.info('Warning! Useless field for NegativeHillPropensity '+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([ fields['s1'] ],[ fields['K'],fields['n'],fields['k'] ])
@@ -358,7 +359,7 @@ cdef class NegativeProportionalHillPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
+                logging.info('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return ([ fields['s1'], fields['d'] ],[ fields['K'],fields['n'],fields['k'] ])
@@ -370,7 +371,7 @@ cdef class NegativeProportionalHillPropensity(Propensity):
             elif key == 'd':
                 self.d_index = species_indices[species['d']]
             else:
-                warnings.warn('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
+                logging.info('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
     def set_parameters(self, parameters, parameter_indices):
         for key in parameters:
             if key == 'K':
@@ -380,7 +381,7 @@ cdef class NegativeProportionalHillPropensity(Propensity):
             elif key == 'k':
                 self.rate_index = parameter_indices[parameters[key]]
             else:
-                warnings.warn('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
+                logging.info('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
 
 
 
@@ -458,7 +459,7 @@ cdef class MassActionPropensity(Propensity):
             elif key == 'k':
                 self.k_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for MassActionPropensity '+str(key))
+                logging.info('Warning! Useless field for MassActionPropensity '+str(key))
 
 
 
@@ -956,7 +957,7 @@ cdef class FixedDelay(Delay):
             if key == 'delay':
                 self.delay_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for fixed delay', key)
+                logging.info('Warning! Useless field for fixed delay', key)
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return [], [fields['delay']]
@@ -979,7 +980,7 @@ cdef class GaussianDelay(Delay):
             elif key == 'std':
                 self.std_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for gaussian delay', key)
+                logging.info('Warning! Useless field for gaussian delay', key)
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return [],[fields['mean'], fields['std']]
@@ -1003,7 +1004,7 @@ cdef class GammaDelay(Delay):
             elif key == 'theta':
                 self.theta_index = parameter_indices[value]
             else:
-                warnings.warn('Warning! Useless field for gamma delay', key)
+                logging.info('Warning! Useless field for gamma delay', key)
 
     def get_species_and_parameters(self, dict fields, **keywords):
         return [],[fields['k'], fields['theta']]
@@ -1887,7 +1888,7 @@ cdef class Model:
     #Sets the value of a parameter in the model
     def set_parameter(self, param_name, param_value):
         if param_name not in self.params2index:
-            warnings.warn('Warning! parameter '+ param_name+" does not show up in any currently defined reactions or rules.")
+            logging.info('Warning! parameter '+ param_name+" does not show up in any currently defined reactions or rules.")
             self._add_param(param_name)
 
         param_index = self.params2index[param_name]
@@ -1921,7 +1922,7 @@ cdef class Model:
                 warning_txt += s+", "
                 self.species_values[i] = 0
         if uninitialized_species:
-            warnings.warn(warning_txt)
+            logging.info(warning_txt)
 
     #Checks if the dictionary dic contains the keyword key.
     #if dic[key] = str: do nothing


### PR DESCRIPTION
mostly replaced with logging.info, except in cases users could fix the problem. In particular:
* When species default to 0 as an initial condition, there is now no warning (but this is logged).
* ODEint failed (but tried again) is now logged instead of a warning
* A couple simulation initialization steps are logged, instead of warned.