### PR TITLE
emcee update `sampler.flatchain` to `sampler.get_chain`

### DIFF
--- a/bioscrape/inference_setup.py
+++ b/bioscrape/inference_setup.py
@@ -392,7 +392,8 @@ class InferenceSetup(object):
             if not convergence_check:
                 warnings.warn('MCMC diagnostics cannot be printed when convergence check is False.')
                 self.convergence_diagnostics = {}
-            self.convergence_diagnostics = {'Autocorrelation time for each parameter':self.autocorrelation_time,
+            else:
+                self.convergence_diagnostics = {'Autocorrelation time for each parameter':self.autocorrelation_time,
                                     'Acceptance fraction (fraction of steps that were accepted)':sampler.acceptance_fraction}
         # Write results
         import csv


### PR DESCRIPTION
The emcee package will deprecate `sampler.flatchain`, this PR changes it to the new way to use this so that there is no deprecation warning from emcee. 