### PR TITLE
Deterministic safe mode

### DIFF
--- a/.github/workflows/install_and_test_package.yml
+++ b/.github/workflows/install_and_test_package.yml
@@ -4,6 +4,7 @@ jobs:
   build:
       runs-on: ${{ matrix.os }}
       strategy:
+        max-parallel: 4
         matrix:
           os: [windows-latest, ubuntu-latest, macos-latest]
           python-version: [3.6, 3.7, 3.8]

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -611,12 +611,14 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
     cdef void calculate_deterministic_derivative(self, double *x, double *dxdt, double t):
         cdef unsigned s
         cdef unsigned j
+        cdef unsigned negative_species = 0
         # Get propensities before doing anything else.
         cdef double *prop = <double*> (self.propensity_buffer.data)
 
         for s in range(self.num_species):
             #Reset negative species concentrations to 0
             if x[s] < 0:
+                negative_species = 1
                 raise RuntimeError(f"Reactions or rules have caused species {s} to go negative!")
 
         #Compute propensiteis
@@ -635,6 +637,8 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
             #Verify that species do not go negative.
             if x[s] <= 0 and dxdt[s] < 0:
                 dxdt[s] = -x[s]
+            else:
+                raise RuntimeError(f"Reactions or rules have caused species {s} to go negative!")
 
 cdef class SSAResult:
     def __init__(self, np.ndarray timepoints, np.ndarray result):

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -534,13 +534,33 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
                          self.reaction_input_indices[self.rxn_ind, ind, 1] = -min(self.update_array[self.s_ind, self.rxn_ind], self.delay_update_array[self.s_ind, self.rxn_ind])
                     ind += 1
 
+
+    cdef void compute_propensities(self, double *state, double *propensity_destination, double time):
+        self.rxn_ind = 0
+        for self.rxn_ind in range(self.num_reactions):
+            self.prop_is_0 = 0
+            self.s_ind = 0
+            while self.reaction_input_indices[self.rxn_ind, self.s_ind, 0] != -1 and self.prop_is_0 == 0:
+                if state[self.reaction_input_indices[self.rxn_ind, self.s_ind, 0]] <= 0 and self.reaction_input_indices[self.rxn_ind, self.s_ind, 1] < 0:
+                    propensity_destination[self.rxn_ind] = 0
+                    self.prop_is_0 = 1
+                self.s_ind+=1
+            if self.prop_is_0 == 0:
+                propensity_destination[self.rxn_ind] = (<Propensity> (self.c_propensities[0][self.rxn_ind]) ).get_propensity(state, self.c_param_values, time)
+
+                #Issue a warning of a propensity goes negative
+                if propensity_destination[self.rxn_ind] < 0:
+                    warnings.warn("Propensity #"+str(self.rxn_ind)+" is negative with value "+str(propensity_destination[self.rxn_ind]) + " setting to 0.")
+                    propensity_destination[self.rxn_ind] = 0
+
+
     cdef void compute_stochastic_propensities(self, double *state, double *propensity_destination, double time):
         self.check_count_function(state, 1)
         self.rxn_ind = 0
         for self.rxn_ind in range(self.num_reactions):
             self.prop_is_0 = 0
             self.s_ind = 0
-            while self.reaction_input_indices[self.rxn_ind, self.s_ind, 0] > -1 and self.prop_is_0 == 0:
+            while self.reaction_input_indices[self.rxn_ind, self.s_ind, 0] != -1 and self.prop_is_0 == 0:
                 if state[self.reaction_input_indices[self.rxn_ind, self.s_ind, 0]] < self.reaction_input_indices[self.rxn_ind, self.s_ind, 1]:
                     propensity_destination[self.rxn_ind] = 0
                     self.prop_is_0 = 1
@@ -589,28 +609,32 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
     # This version safegaurds against species counts going negative 
     # by not allowing reactions to fire if they consume a species of 0 concentration.
     cdef void calculate_deterministic_derivative(self, double *x, double *dxdt, double t):
-        # Get propensities before doing anything else.
-        cdef double *prop = <double*> (self.propensity_buffer.data)
-        self.compute_propensities(x,  prop, t)
-
         cdef unsigned s
         cdef unsigned j
-        for s in range(self.num_species):
+        # Get propensities before doing anything else.
+        cdef double *prop = <double*> (self.propensity_buffer.data)
 
+        for s in range(self.num_species):
             #Reset negative species concentrations to 0
             if x[s] < 0:
-                x[s] = 0
+                raise RuntimeError(f"Reactions or rules have caused species {s} to go negative!")
 
+        #Compute propensiteis
+        self.compute_propensities(x,  prop, t)
+
+        #Compute Derivative
+        for s in range(self.num_species):
             dxdt[s] = 0
+            #Skip reactions that consume species of 0 concentration
             for j in range(self.S_indices[s].size()):
                 if self.S_values[s][j] <= 0 and x[s] <= 0:
-                    pass #Skip reactions that consume species of 0 concentration
+                    pass 
                 else:
                     dxdt[s] += prop[ self.S_indices[s][j]  ] * self.S_values[s][j]
 
             #Verify that species do not go negative.
             if x[s] <= 0 and dxdt[s] < 0:
-                dxdt[s] = 0
+                dxdt[s] = -x[s]
 
 cdef class SSAResult:
     def __init__(self, np.ndarray timepoints, np.ndarray result):

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -637,8 +637,8 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
             #Verify that species do not go negative.
             if x[s] <= 0 and dxdt[s] < 0:
                 dxdt[s] = -x[s]
-            else:
                 raise RuntimeError(f"Reactions or rules have caused species {s} to go negative!")
+
 
 cdef class SSAResult:
     def __init__(self, np.ndarray timepoints, np.ndarray result):

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -1967,10 +1967,12 @@ cdef class Model:
             #reaction_update_dict = self.reaction_updates[reaction_index]
             #delay_reaction_update_dict = self.delay_reaction_updates[reaction_index]
             for sp in reaction_update_dict:
-                self.update_array[self.species2index[sp],reaction_index] = reaction_update_dict[sp]
+                if sp != "":
+                    self.update_array[self.species2index[sp],reaction_index] = reaction_update_dict[sp]
 
             for sp in delay_reaction_update_dict:
-                self.delay_update_array[self.species2index[sp],reaction_index] = delay_reaction_update_dict[sp]
+                if sp != "":
+                    self.delay_update_array[self.species2index[sp],reaction_index] = delay_reaction_update_dict[sp]
 
         return self.update_array, self.delay_update_array
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -20,7 +20,7 @@ def test_safe_modelsiminterface_deterministic():
 
     sim_det = DeterministicSimulator()
 
-    timepoints = np.arange(0, 10.0, .01)
+    timepoints = np.arange(0, 10.0, .001)
 
     i_fast = ModelCSimInterface(m)
     i_fast.py_prep_deterministic_simulation()

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -40,11 +40,14 @@ def test_safe_modelsiminterface_deterministic():
     i_safe.py_prep_deterministic_simulation()
     R_det_s = sim_det.py_simulate(i_safe, timepoints).py_get_result()
 
+
+
     i_fast = ModelCSimInterface(m)
     i_fast.py_prep_deterministic_simulation()
     R_det = sim_det.py_simulate(i_fast, timepoints).py_get_result()
+    assert np.all(R_det[-100:, 0] < 0)
 
-    assert not np.allclose(R_det_s[:100, :], R_det[:100, :])
+    assert not np.allclose(R_det_s[-100:, :], R_det[-100:, :])
 
 
 #Stochastic test

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -36,7 +36,12 @@ def test_safe_modelsiminterface_deterministic():
     #Running for longer should produce an different outputs
     #NOTE: an error will be printed, but it is not raised due to being produced inside ODEint
     timepoints = np.arange(0, 100.0, .01)
+    i_safe = SafeModelCSimInterface(m)
+    i_safe.py_prep_deterministic_simulation()
     R_det_s = sim_det.py_simulate(i_safe, timepoints).py_get_result()
+
+    i_fast = ModelCSimInterface(m)
+    i_fast.py_prep_deterministic_simulation()
     R_det = sim_det.py_simulate(i_fast, timepoints).py_get_result()
 
     assert not np.allclose(R_det_s[:100, :], R_det[:100, :])

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -20,6 +20,8 @@ def test_safe_modelsiminterface_deterministic():
 
     sim_det = DeterministicSimulator()
 
+    timepoints = np.arange(0, 10.0, .01)
+
     i_fast = ModelCSimInterface(m)
     i_fast.py_prep_deterministic_simulation()
     R_det = sim_det.py_simulate(i_fast, timepoints).py_get_result()
@@ -30,13 +32,15 @@ def test_safe_modelsiminterface_deterministic():
 
     #The beginnings of the simulations should be the same
     assert np.allclose(R_det_s[:100, :], R_det[:100, :])
-    #The ends of the simulations should be different
-    assert not np.allclose(R_det_s[100:, :], R_det[100:, :])
-    #the non safe simulation should go below 0
-    assert (R_det[-100:, 0] <= 0).all()
-    #the safe simulation should stop at 0
-    #the non safe simulation should go below 0
-    assert (np.round(R_det_s[-100:, 0], 6) == 0).all()
+
+    #Running for longer should produce an different outputs
+    #NOTE: an error will be printed, but it is not raised due to being produced inside ODEint
+    timepoints = np.arange(0, 100.0, .01)
+    R_det_s = sim_det.py_simulate(i_safe, timepoints).py_get_result()
+    R_det = sim_det.py_simulate(i_fast, timepoints).py_get_result()
+
+    assert not np.allclose(R_det_s[:100, :], R_det[:100, :])
+
 
 #Stochastic test
 def test_safe_modelsiminterface_stochastic():


### PR DESCRIPTION
deterministic safe mode now prints errors when species go negative. Due to issues caused by being called within ODEint, it cannot force the output to be positive.