### PR TITLE
Update github action versions for pypi update

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -10,9 +10,9 @@ jobs:
     environment: Release Deploy
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12' 
 


### PR DESCRIPTION
Some of the GitHub action versions were deprecated..updating with this PR.