### PR TITLE
Update pypi_release.yml action to update pypi distribution

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -19,12 +19,27 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build  
+          pip install build auditwheel 
 
       - name: Build the package
         run: |
           python -m build
-
+          
+      - name: Check if auditwheel is needed
+        run: |
+          for whl in dist/*.whl; do
+            auditwheel show "$whl" || echo "Auditwheel check failed!"
+          done
+          
+      - name: Repair wheel with auditwheel
+        run: |
+          for whl in dist/*.whl; do
+            auditwheel repair "$whl" --wheel-dir dist/ || echo "Auditwheel repair skipped!"
+          done
+          
+      - name: List built wheels (debugging step)
+        run: ls -lh dist/
+        
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -18,8 +18,9 @@ jobs:
             /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build auditwheel && \
             /opt/python/cp312-cp312/bin/python -m pip install -r requirements.txt && \
             /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist && \
-            rm -f /io/dist/*linux_x86_64.whl && \
             auditwheel repair /io/dist/*.whl --plat manylinux_2_28_x86_64 --wheel-dir /io/dist"
+            rm -f /io/dist/*linux_x86_64.whl && \
+
 
       - name: List built wheels (debugging step)
         run: ls -lh dist/

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -18,7 +18,8 @@ jobs:
             /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build auditwheel && \
             /opt/python/cp312-cp312/bin/python -m pip install -r requirements.txt && \
             /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist && \
-            auditwheel repair /io/dist/*.whl --wheel-dir /io/dist"
+            rm -f /io/dist/*linux_x86_64.whl && \
+            auditwheel repair /io/dist/*.whl --plat manylinux_2_28_x86_64 --wheel-dir /io/dist"
 
       - name: List built wheels (debugging step)
         run: ls -lh dist/

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -18,8 +18,8 @@ jobs:
             /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build auditwheel && \
             /opt/python/cp312-cp312/bin/python -m pip install -r requirements.txt && \
             /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist && \
-            auditwheel repair /io/dist/*.whl --plat manylinux_2_28_x86_64 --wheel-dir /io/dist"
-            rm -f /io/dist/*linux_x86_64.whl && \
+            auditwheel repair /io/dist/*.whl --plat manylinux_2_28_x86_64 --wheel-dir /io/dist && \
+            rm -f /io/dist/*linux_x86_64.whl"
 
 
       - name: List built wheels (debugging step)

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -20,11 +20,7 @@ jobs:
             /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist && \
             auditwheel repair /io/dist/*.whl --plat manylinux_2_28_x86_64 --wheel-dir /io/dist && \
             rm -f /io/dist/*linux_x86_64.whl"
-
-
-      - name: List built wheels (debugging step)
-        run: ls -lh dist/
-
+            
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -11,35 +11,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12' 
+      
+      - name: Build inside manylinux_2_28 container
+        run: |
+          docker run --rm -v $(pwd):/io quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "\
+            /opt/python/cp312-cp312m/bin/python -m pip install --upgrade pip build && \
+            /opt/python/cp312-cp312m/bin/python -m pip install -r /io/requirements.txt && \
+            /opt/python/cp312-cp312m/bin/python -m build --wheel --outdir /io/dist"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build auditwheel 
-
-      - name: Build the package
-        run: |
-          python -m build
-          
-      - name: Check if auditwheel is needed
-        run: |
-          for whl in dist/*.whl; do
-            auditwheel show "$whl" || echo "Auditwheel check failed!"
-          done
-          
-      - name: Repair wheel with auditwheel
-        run: |
-          for whl in dist/*.whl; do
-            auditwheel repair "$whl" --wheel-dir dist/ || echo "Auditwheel repair skipped!"
-          done
-          
       - name: List built wheels (debugging step)
         run: ls -lh dist/
-        
+
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -15,9 +15,10 @@ jobs:
       - name: Build inside manylinux_2_28 container
         run: |
           docker run --rm -v $(pwd):/io -w /io quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "\
-            /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build && \
-            /opt/python/cp312-cp312/bin/python -m pip install -r /io/requirements.txt && \
-            /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist"
+            /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build auditwheel && \
+            /opt/python/cp312-cp312/bin/python -m pip install -r requirements.txt && \
+            /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist && \
+            auditwheel repair /io/dist/*.whl --wheel-dir /io/dist"
 
       - name: List built wheels (debugging step)
         run: ls -lh dist/

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Build inside manylinux_2_28 container
         run: |
           docker run --rm -v $(pwd):/io quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "\
-            /opt/python/cp312-cp312m/bin/python -m pip install --upgrade pip build && \
-            /opt/python/cp312-cp312m/bin/python -m pip install -r /io/requirements.txt && \
-            /opt/python/cp312-cp312m/bin/python -m build --wheel --outdir /io/dist"
+            /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build && \
+            /opt/python/cp312-cp312/bin/python -m pip install -r /io/requirements.txt && \
+            /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist"
 
       - name: List built wheels (debugging step)
         run: ls -lh dist/

--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -14,7 +14,7 @@ jobs:
       
       - name: Build inside manylinux_2_28 container
         run: |
-          docker run --rm -v $(pwd):/io quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "\
+          docker run --rm -v $(pwd):/io -w /io quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "\
             /opt/python/cp312-cp312/bin/python -m pip install --upgrade pip build && \
             /opt/python/cp312-cp312/bin/python -m pip install -r /io/requirements.txt && \
             /opt/python/cp312-cp312/bin/python -m build --wheel --outdir /io/dist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools>=64", "Cython", "numpy", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.distutils.bdist_wheel]
-universal = true
-
 [project]
 name = "Bioscrape"
 version = "1.3.0"


### PR DESCRIPTION
Two changes were needed to run pypi release github action successfully:
- Use the recommended `[manylinux](https://github.com/pypa/manylinux)` to distribute python packages
- Add auditwheel repair because pypi rejects linux_x86 wheel, following this advice on: https://github.com/astral-sh/uv/issues/9596#issuecomment-2523208000

Removed bdist universal tag in pyproject because universal wheel distribution was deprecated in setuptools.