### PR TITLE
fix rounding errors in Hill functions

### DIFF
--- a/.github/workflows/deploy_bioscrape.yml
+++ b/.github/workflows/deploy_bioscrape.yml
@@ -1,9 +1,9 @@
 name: deploy_bioscrape
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]  
+    branches: ["main"]  
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/deploy_bioscrape.yml
+++ b/.github/workflows/deploy_bioscrape.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.11", "3.12"]
-
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy_bioscrape.yml
+++ b/.github/workflows/deploy_bioscrape.yml
@@ -10,10 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.11", "3.12"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.8"
+        python-version: ["3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -18,6 +18,10 @@ from bioscrape.sbmlutil import add_species, add_parameter, add_reaction, add_rul
 
 from libc.math cimport log, sqrt, cos, round, exp, fabs
 
+# Define static epsilon for handling rounding errors
+from libcpp.limits cimport numeric_limits
+cdef float float_epsilon = numeric_limits[float].epsilon()
+
 ##################################################                ####################################################
 ######################################              PROPENSITY TYPES                    ##############################
 #################################################                     ################################################
@@ -222,6 +226,8 @@ cdef class PositiveHillPropensity(Propensity):
         cdef double K = params[self.K_index]
         cdef double n = params[self.n_index]
         cdef double rate = params[self.rate_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return rate * (X / K) ** n / (1 + (X/K)**n)
 
     cdef double get_volume_propensity(self, double *state, double *params, double volume, double time):
@@ -229,6 +235,8 @@ cdef class PositiveHillPropensity(Propensity):
         cdef double K = params[self.K_index]
         cdef double n = params[self.n_index]
         cdef double rate = params[self.rate_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return rate * (X / K) ** n / (1 + (X/K)**n)
 
     def initialize(self, dict param_dictionary, dict species_indices, dict parameter_indices):
@@ -266,6 +274,8 @@ cdef class PositiveProportionalHillPropensity(Propensity):
         cdef double n = params[self.n_index]
         cdef double rate = params[self.rate_index]
         cdef double d = state[self.d_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return rate * d *  (X / K) ** n / (1 + (X/K)**n)
 
     cdef double get_volume_propensity(self, double *state, double *params, double volume, double time):
@@ -274,6 +284,8 @@ cdef class PositiveProportionalHillPropensity(Propensity):
         cdef double n = params[self.n_index]
         cdef double d = state[self.d_index]
         cdef double rate = params[self.rate_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return d * rate * (X / K) ** n / (1 + (X/K)**n)
 
 
@@ -357,6 +369,8 @@ cdef class NegativeProportionalHillPropensity(Propensity):
         cdef double n = params[self.n_index]
         cdef double rate = params[self.rate_index]
         cdef double d = state[self.d_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return rate * d *  1/ (1 + (X/K)**n)
 
     cdef double get_volume_propensity(self, double *state, double *params, double volume, double time):
@@ -365,6 +379,8 @@ cdef class NegativeProportionalHillPropensity(Propensity):
         cdef double n = params[self.n_index]
         cdef double d = state[self.d_index]
         cdef double rate = params[self.rate_index]
+        if X < 0 and abs(X) < float_epsilon:
+            X = 0.        # Fix rounding errors
         return d * rate * 1 / (1 + (X/K)**n)
 
 


### PR DESCRIPTION
This is a small change in the way propensity functions are handled to avoid errors where `X ** n` fails if `X` is a small negative number (like -1e-30).  This occurs fairly frequently in BioSCRAPE simulations when a variable is initialized to zero (and apparently numerical errors cause it to go negative).
