### PR TITLE
Migrate public docstrings to numpydoc convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Docstring style: Follow the conventions in `contributing.md`.

--- a/bioscrape/analysis.py
+++ b/bioscrape/analysis.py
@@ -20,8 +20,8 @@ def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
     Compute the sensitivity of a model's trajectories to its parameters.
 
     Simulates `model` deterministically over `timepoints` and returns the
-    sensitivity coefficients $s_{ij} = \partial x_i/\partial p_j$ for each
-    state $x_i$, parameter $p_j$, and time point.
+    sensitivity coefficients s_ij = d(x_i)/d(p_j) for each
+    state x_i, parameter p_j, and time point.
 
     Parameters
     ----------
@@ -30,7 +30,7 @@ def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
     timepoints : numpy.ndarray
         Array of time points at which to compute the sensitivity coefficients.
     normalize : bool
-        If True, each sensitivity coefficient is normalized by $x_i/p_j$ at
+        If True, each sensitivity coefficient is normalized by x_i/p_j at
         that time point. If False, the coefficients are not normalized.
     **kwargs
         Additional keyword arguments passed to `SensitivityAnalysis` and
@@ -54,7 +54,7 @@ def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
 
 def py_get_jacobian(model: Model, state: Union[list, np.ndarray], **kwargs) -> np.ndarray:
     r"""
-    Compute the Jacobian $J = \partial f/\partial x$ of a model.
+    Compute the Jacobian J = d(f)/d(x) of a model.
 
     Parameters
     ----------
@@ -78,7 +78,7 @@ def py_get_jacobian(model: Model, state: Union[list, np.ndarray], **kwargs) -> n
 def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray],
                                     param_name: str, **kwargs) -> np.ndarray:
     r"""
-    Compute a model's sensitivity $Z_j = \partial f/\partial p_j$ to $p_j$.
+    Compute a model's sensitivity Z_j = d(f)/d(p_j) to p_j.
 
     Parameters
     ----------
@@ -86,9 +86,9 @@ def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray]
         The bioscrape model to analyze.
     state : list or numpy.ndarray
         The state values (vector of length `n`) at which to compute
-        $\partial f/\partial p_j$.
+        d(f)/d(p_j).
     param_name : str
-        The name of the parameter $p_j$ to differentiate with respect to.
+        The name of the parameter p_j to differentiate with respect to.
     **kwargs
         Additional keyword arguments passed to
         `SensitivityAnalysis.compute_Zj`, including `method` (the
@@ -97,8 +97,7 @@ def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray]
     Returns
     -------
     numpy.ndarray
-        Vector of length `n` giving $\partial f_i/\partial p_j$ for each state
-        $i$.
+        Vector of length `n` giving d(f_i)/d(p_j) for each state i.
     """
     return SensitivityAnalysis(model).compute_Zj(state, param_name, **kwargs)
 
@@ -108,8 +107,8 @@ class SensitivityAnalysis(Model):
 
     Computes the sensitivity of a model's deterministic trajectories to its
     parameters, using finite-difference approximations of the Jacobian
-    $J = \partial f/\partial x$ and the parameter-sensitivity vector
-    $Z_j = \partial f/\partial p_j$, where $f$ is the model's right-hand side.
+    J = d(f)/d(x) and the parameter-sensitivity vector
+    Z_j = d(f)/d(p_j), where f is the model's right-hand side.
     See `py_sensitivity_analysis` for the higher-level, user-facing interface
     built on this class.
 
@@ -151,10 +150,10 @@ class SensitivityAnalysis(Model):
 
     def compute_J(self, x, time = 0.0, **kwargs):
         r"""
-        Compute the Jacobian $J = \partial f/\partial x$ at a point `x`.
+        Compute the Jacobian J = d(f)/d(x) at a point `x`.
 
         Uses a finite-difference approximation of the model's right-hand side
-        $f$; see `method` below for the available approximation orders.
+        f; see `method` below for the available approximation orders.
 
         Parameters
         ----------
@@ -226,9 +225,9 @@ class SensitivityAnalysis(Model):
         
     def compute_Zj(self, x, param_name, time = 0.0, **kwargs):
         r"""
-        Compute $Z_j = \partial f/\partial p_j$ at a point `x`.
+        Compute Z_j = d(f)/d(p_j) at a point `x`.
 
-        Uses the same finite-difference methods as `compute_J`, where $p_j$
+        Uses the same finite-difference methods as `compute_J`, where p_j
         is the parameter named `param_name`.
 
         Parameters
@@ -237,7 +236,7 @@ class SensitivityAnalysis(Model):
             The state (vector of length `n`) at which to evaluate the
             sensitivity.
         param_name : str
-            The name of the parameter $p_j$ to differentiate with respect to.
+            The name of the parameter p_j to differentiate with respect to.
         time : float, optional
             The time at which to evaluate the (possibly time-varying) model
             (default 0.0).
@@ -247,8 +246,7 @@ class SensitivityAnalysis(Model):
         Returns
         -------
         numpy.ndarray
-            Vector of length `n` giving $\partial f_i/\partial p_j$ for each
-            state $i$.
+            Vector of length `n` giving d(f_i)/d(p_j) for each state i.
         """
         method = kwargs.get('method')
         if method is None:
@@ -309,8 +307,8 @@ class SensitivityAnalysis(Model):
         r"""
         Compute the sensitivity coefficients for each parameter.
 
-        Computes $S_j = \partial x/\partial p_j$ for each parameter $p_j$, at
-        each time point, by integrating the sensitivity ODE $dS/dt = JS + Z_j$
+        Computes S_j = d(x)/d(p_j) for each parameter p_j, at
+        each time point, by integrating the sensitivity ODE dS/dt = J*S + Z_j
         forward in time using the Jacobian and parameter-sensitivity vectors
         from `compute_J` and `compute_Zj`.
 
@@ -337,7 +335,7 @@ class SensitivityAnalysis(Model):
         -------
         numpy.ndarray
             Array of shape `(len(timepoints), len(params), n)` containing the
-            sensitivity coefficients $S_j$ for each parameter and time point.
+            sensitivity coefficients S_j for each parameter and time point.
         """
         def sensitivity_ode(t, x, J, Z):
             # ODE to solve for sensitivity coefficient S

--- a/bioscrape/analysis.py
+++ b/bioscrape/analysis.py
@@ -32,11 +32,13 @@ def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
     normalize : bool
         If True, each sensitivity coefficient is normalized by x_i/p_j at
         that time point. If False, the coefficients are not normalized.
-    **kwargs
-        Additional keyword arguments passed to `SensitivityAnalysis` and
-        `SensitivityAnalysis.compute_SSM`, including `dx` (the
-        finite-difference step size, default 0.01) and `precision` (the number
-        of decimal places to round results to, default 10).
+    dx : float, default 0.01
+        Finite-difference step size used when approximating derivatives.
+    precision : int, default 10
+        Number of decimal places to round returned sensitivity values to.
+    method : str, optional
+        The finite-difference method to use; see
+        `SensitivityAnalysis.compute_J`.
 
     Returns
     -------
@@ -63,10 +65,12 @@ def py_get_jacobian(model: Model, state: Union[list, np.ndarray], **kwargs) -> n
     state : list or numpy.ndarray
         The state values (vector of length `n`) at which to compute the
         Jacobian.
-    **kwargs
-        Additional keyword arguments passed to
-        `SensitivityAnalysis.compute_J`, including `method` (the
-        finite-difference method to use) and `time`.
+    method : str, optional
+        The finite-difference method to use; see
+        `SensitivityAnalysis.compute_J`.
+    time : float, optional
+        The time at which to evaluate the (possibly time-varying)
+        model (default 0.0).
 
     Returns
     -------
@@ -89,10 +93,12 @@ def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray]
         d(f)/d(p_j).
     param_name : str
         The name of the parameter p_j to differentiate with respect to.
-    **kwargs
-        Additional keyword arguments passed to
-        `SensitivityAnalysis.compute_Zj`, including `method` (the
-        finite-difference method to use) and `time`.
+    method : str, optional
+        The finite-difference method to use; see
+        `SensitivityAnalysis.compute_Zj`.
+    time : float, optional
+        The time at which to evaluate the (possibly time-varying)
+        model (default 0.0).
 
     Returns
     -------
@@ -327,9 +333,8 @@ class SensitivityAnalysis(Model):
         params : list of str, optional
             The parameters to compute sensitivities for. Defaults to all of
             the model's parameters.
-        **kwargs
-            Additional keyword arguments passed to `compute_J` and
-            `compute_Zj`, including `method`.
+        method : str, optional
+            The finite-difference method to use; see `compute_J`.
 
         Returns
         -------

--- a/bioscrape/analysis.py
+++ b/bioscrape/analysis.py
@@ -1,3 +1,12 @@
+"""
+Local sensitivity analysis of bioscrape models.
+
+Provides finite-difference sensitivity analysis of a deterministically
+simulated `~bioscrape.types.Model` with respect to its parameters, via
+`SensitivityAnalysis` and the module-level convenience functions
+`py_sensitivity_analysis`, `py_get_jacobian`, and
+`py_get_sensitivity_to_parameter`.
+"""
 import warnings
 from bioscrape.types import Model
 from bioscrape.simulator import ModelCSimInterface, DeterministicSimulator
@@ -5,24 +14,35 @@ from scipy.integrate import odeint
 import numpy as np
 from typing import List, Union
 
-def py_sensitivity_analysis(model: Model, timepoints: np.ndarray, 
+def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
                             normalize: bool, **kwargs) -> np.ndarray:
-    """User interface function to perform sensitivity analysis 
-    on a bioscrape model. The sensitivity coefficients are computed 
-    where each coefficient s_ij = rate of change of x_i with parameter p_j
-    for each time point in timepoints.
+    r"""
+    Compute the sensitivity of a model's trajectories to its parameters.
 
-    Args:
-        model (bioscrape.types.Model): A bioscrape Model object
-        timepoints (numpy.ndarray): Array of time points.
-        normalize (bool): when `True` the sensitivity coefficients returned are 
-                          normalized by state values at each time 
-                          (divides each coefficient by x_i/p_j).
-                          when `False` the sensitivity coefficients are not normalized.
+    Simulates `model` deterministically over `timepoints` and returns the
+    sensitivity coefficients $s_{ij} = \partial x_i/\partial p_j$ for each
+    state $x_i$, parameter $p_j$, and time point.
 
-    Returns:
-        numpy.ndarray: A numpy array of size:
-                       len(timepoints) x len(parameters) x len(states)
+    Parameters
+    ----------
+    model : Model
+        The bioscrape model to analyze.
+    timepoints : numpy.ndarray
+        Array of time points at which to compute the sensitivity coefficients.
+    normalize : bool
+        If True, each sensitivity coefficient is normalized by $x_i/p_j$ at
+        that time point. If False, the coefficients are not normalized.
+    **kwargs
+        Additional keyword arguments passed to `SensitivityAnalysis` and
+        `SensitivityAnalysis.compute_SSM`, including `dx` (the
+        finite-difference step size, default 0.01) and `precision` (the number
+        of decimal places to round results to, default 10).
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape `(len(timepoints), len(parameters), len(states))`
+        containing the sensitivity coefficients.
     """
     dx = kwargs.get("dx", 0.01)
     precision = kwargs.get("precision", 10) 
@@ -33,43 +53,79 @@ def py_sensitivity_analysis(model: Model, timepoints: np.ndarray,
     return sens_obj.compute_SSM(solutions_array, timepoints, normalize, **kwargs)
 
 def py_get_jacobian(model: Model, state: Union[list, np.ndarray], **kwargs) -> np.ndarray:
-    """User interfacce function to compute Jacobian (df/dx) of the model.
+    r"""
+    Compute the Jacobian $J = \partial f/\partial x$ of a model.
 
-    Args:
-        model (Model): Bioscrape Model
-        state (Union[list, np.ndarray]): The state values (vector of length n) 
-                                         at which to compute the Jacobian
+    Parameters
+    ----------
+    model : Model
+        The bioscrape model to analyze.
+    state : list or numpy.ndarray
+        The state values (vector of length `n`) at which to compute the
+        Jacobian.
+    **kwargs
+        Additional keyword arguments passed to
+        `SensitivityAnalysis.compute_J`, including `method` (the
+        finite-difference method to use) and `time`.
 
-    Returns:
-        np.ndarray: A (n x n) Jacobian matrix, where n = len(state)
+    Returns
+    -------
+    numpy.ndarray
+        The `n` x `n` Jacobian matrix, where `n = len(state)`.
     """
     return SensitivityAnalysis(model).compute_J(state, **kwargs)
 
-def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray], 
+def py_get_sensitivity_to_parameter(model: Model, state: Union[list, np.ndarray],
                                     param_name: str, **kwargs) -> np.ndarray:
-    """User interface function to compute the sensitivity to parameter (df/dp)
-    where p is the parameter and f is the model
+    r"""
+    Compute a model's sensitivity $Z_j = \partial f/\partial p_j$ to $p_j$.
 
-    Args:
-        model (Model): Bioscrape Model
-        state (Union[list, np.ndarray]): The state values (vector of length n) 
-                                         at which to compute df/dp
-        param_name (str): The parameter name for which df/dp is computed
+    Parameters
+    ----------
+    model : Model
+        The bioscrape model to analyze.
+    state : list or numpy.ndarray
+        The state values (vector of length `n`) at which to compute
+        $\partial f/\partial p_j$.
+    param_name : str
+        The name of the parameter $p_j$ to differentiate with respect to.
+    **kwargs
+        Additional keyword arguments passed to
+        `SensitivityAnalysis.compute_Zj`, including `method` (the
+        finite-difference method to use) and `time`.
 
-    Returns:
-        np.ndarray: A np.ndarray of size (n x 1), where n is the length of state 
+    Returns
+    -------
+    numpy.ndarray
+        Vector of length `n` giving $\partial f_i/\partial p_j$ for each state
+        $i$.
     """
     return SensitivityAnalysis(model).compute_Zj(state, param_name, **kwargs)
 
 class SensitivityAnalysis(Model):
+    r"""
+    Local sensitivity analysis for bioscrape models.
+
+    Computes the sensitivity of a model's deterministic trajectories to its
+    parameters, using finite-difference approximations of the Jacobian
+    $J = \partial f/\partial x$ and the parameter-sensitivity vector
+    $Z_j = \partial f/\partial p_j$, where $f$ is the model's right-hand side.
+    See `py_sensitivity_analysis` for the higher-level, user-facing interface
+    built on this class.
+
+    Parameters
+    ----------
+    M : Model
+        The bioscrape model to analyze.
+    dx : float, optional
+        Finite-difference step size used when approximating derivatives
+        (default 0.01).
+    precision : int, optional
+        Number of decimal places to round returned sensitivity values to
+        (default 10).
+    """
     def __init__(self, M, dx = 0.01, precision = 10):
-        """
-        Local Sensitivity Analysis for Bioscrape models.
-        Arguments:
-        * M: The Bioscrape Model object.
-        * dx: Small parameter used in approximate computation methods. 
-        * precision: the number of decimal places to round to
-        """
+        """See class docstring."""
         self.M = M
         sim = ModelCSimInterface(self.M)
         sim.py_prep_deterministic_simulation()
@@ -94,10 +150,29 @@ class SensitivityAnalysis(Model):
         return derivative_array
 
     def compute_J(self, x, time = 0.0, **kwargs):
-        """
-        Compute the Jacobian J = df/dx at a point x.
-        Returns a matrix of size n x n.
-        Uses fourth-order central difference method to compute Jacobian
+        r"""
+        Compute the Jacobian $J = \partial f/\partial x$ at a point `x`.
+
+        Uses a finite-difference approximation of the model's right-hand side
+        $f$; see `method` below for the available approximation orders.
+
+        Parameters
+        ----------
+        x : array_like
+            The state (vector of length `n`) at which to evaluate the
+            Jacobian.
+        time : float, optional
+            The time at which to evaluate the (possibly time-varying) model
+            (default 0.0).
+        method : str, optional
+            The finite-difference method to use:
+            'fourth_order_central_difference' (default), 'central_difference',
+            'backward_difference', or 'forward_difference'.
+
+        Returns
+        -------
+        numpy.ndarray
+            The `n` x `n` Jacobian matrix.
         """
         method = kwargs.get('method')
         if method is None:
@@ -150,9 +225,30 @@ class SensitivityAnalysis(Model):
         return np.round(J, decimals = self.precision)
         
     def compute_Zj(self, x, param_name, time = 0.0, **kwargs):
-        """
-        Compute Z_j, i.e. df/dparam_name at a particular point x
-        Returns a vector of size n x 1. 
+        r"""
+        Compute $Z_j = \partial f/\partial p_j$ at a point `x`.
+
+        Uses the same finite-difference methods as `compute_J`, where $p_j$
+        is the parameter named `param_name`.
+
+        Parameters
+        ----------
+        x : array_like
+            The state (vector of length `n`) at which to evaluate the
+            sensitivity.
+        param_name : str
+            The name of the parameter $p_j$ to differentiate with respect to.
+        time : float, optional
+            The time at which to evaluate the (possibly time-varying) model
+            (default 0.0).
+        method : str, optional
+            The finite-difference method to use; see `compute_J`.
+
+        Returns
+        -------
+        numpy.ndarray
+            Vector of length `n` giving $\partial f_i/\partial p_j$ for each
+            state $i$.
         """
         method = kwargs.get('method')
         if method is None:
@@ -210,18 +306,38 @@ class SensitivityAnalysis(Model):
         return np.round(Z, decimals = self.precision)
 
     def compute_SSM(self, solutions, timepoints, normalize = False, params = None, **kwargs):
-        """
-        Returns the sensitivity coefficients S_j for each parameter p_j. 
-        Solutions is the ODE solution to self for timepoints.
-        Solutions is of shape (len(timepoints), n), where n is the len(x).
-        The sensitivity coefficients are written in a sensitivity matrix SSM of size len(timepoints) x len(params) x n
-        If normalize argument is true, the coefficients are normalized by the nominal value of each paramneter.
-        Arguments:
-        * solutions: Pandas dataframe object returned by py_simulate_model that contains solutions for all model variables.
-        * timepoints: The time points at which sensitivity coefficients are needed (this is the same as timepoints used for solutions).
-        * normalize: (bool, default is False): When set to True, the returned sensitivity coefficients are normalized with state and parameter values.
-        * params: (list of parameters, default is None): The parameters to compute sensitivty to. When None defaults to all model parameters
-        * kwargs: Other kwargs passed to `compute_J` and `compute_Z` functions.
+        r"""
+        Compute the sensitivity coefficients for each parameter.
+
+        Computes $S_j = \partial x/\partial p_j$ for each parameter $p_j$, at
+        each time point, by integrating the sensitivity ODE $dS/dt = JS + Z_j$
+        forward in time using the Jacobian and parameter-sensitivity vectors
+        from `compute_J` and `compute_Zj`.
+
+        Parameters
+        ----------
+        solutions : array_like
+            The deterministic trajectory of the model (e.g. as returned by
+            `~bioscrape.simulator.py_simulate_model`) evaluated at
+            `timepoints`, of shape `(len(timepoints), n)`.
+        timepoints : numpy.ndarray
+            The time points at which `solutions` was computed and at which
+            sensitivity coefficients are returned.
+        normalize : bool, optional
+            If True, normalize the returned coefficients by the nominal
+            parameter and state values (default False).
+        params : list of str, optional
+            The parameters to compute sensitivities for. Defaults to all of
+            the model's parameters.
+        **kwargs
+            Additional keyword arguments passed to `compute_J` and
+            `compute_Zj`, including `method`.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape `(len(timepoints), len(params), n)` containing the
+            sensitivity coefficients $S_j$ for each parameter and time point.
         """
         def sensitivity_ode(t, x, J, Z):
             # ODE to solve for sensitivity coefficient S
@@ -265,9 +381,26 @@ class SensitivityAnalysis(Model):
 
     def normalize_SSM(self, SSM, solutions, params_values):
         """
-        Returns normalized sensitivity coefficients. 
-        Multiplies each sensitivity coefficient with the corresponding parameter p_j
-        Divides the result by the corresponding state to obtain the normalized coefficient that is returned.
+        Normalize sensitivity coefficients by parameter and state values.
+
+        Multiplies each sensitivity coefficient by its corresponding parameter
+        value and divides by the corresponding state value.
+
+        Parameters
+        ----------
+        SSM : numpy.ndarray
+            Sensitivity coefficients as returned by `compute_SSM`, of shape
+            `(len(timepoints), len(params), n)`.
+        solutions : array_like
+            The state trajectory used to compute `SSM`, of shape
+            `(len(timepoints), n)`.
+        params_values : array_like
+            The nominal value of each parameter in `SSM`, in the same order.
+
+        Returns
+        -------
+        numpy.ndarray
+            The normalized sensitivity coefficients, same shape as `SSM`.
         """
         n = np.shape(solutions)[1]
         SSM_normalized = np.zeros(np.shape(SSM))

--- a/bioscrape/inference.pyx
+++ b/bioscrape/inference.pyx
@@ -1164,6 +1164,16 @@ def py_inference(Model = None, params_to_estimate = None, exp_data = None, initi
     """
     User-level interface for Bayesian parameter inference.
 
+    Fits `params_to_estimate` to `exp_data` via Markov Chain Monte
+    Carlo (MCMC) sampling, using
+    `emcee <https://emcee.readthedocs.io/>`_ under the hood. Returns
+    the `emcee` sampler (holding the full set of posterior samples)
+    together with the `~bioscrape.inference_setup.InferenceSetup`
+    object that orchestrated the run; unless `plot_show=False`, it
+    also plots the resulting posterior parameter distributions, and
+    always writes the raw samples and a fit summary to
+    `filename_csv`/`filename_txt`.
+
     Parameters
     ----------
     Model : Model

--- a/bioscrape/inference.pyx
+++ b/bioscrape/inference.pyx
@@ -101,6 +101,7 @@ cdef class UniformDistribution(Distribution):
         The upper bound in each dimension; must be the same shape as `lb`.
     """
     def __init__(self, np.ndarray lb, np.ndarray ub):
+        """See class docstring."""
         self.dimension = lb.shape[0]
         self.lower_bounds = lb.copy()
         self.upper_bounds = ub.copy()
@@ -161,6 +162,7 @@ cdef class Data():
         The number of samples/trajectories (default 1).
     """
     def __init__(self, np.ndarray timepoints = None, np.ndarray measurements = None, list measured_species = [], unsigned N = 1):
+        """See class docstring."""
         self.set_data(timepoints, measurements, measured_species, N)
 
     def set_data(self,np.ndarray timepoints, np.ndarray measurements, list measured_species, unsigned N):
@@ -503,6 +505,7 @@ cdef class ModelLikelihood(Likelihood):
     def __init__(self, model = None, init_state = {}, init_params = {},
                  interface = None, simulator = None, data = None,
                  **keywords):
+        """See class docstring."""
         self.set_model(model, simulator, interface)
         self.set_likelihood_options(**keywords)
         if isinstance(init_state, dict):
@@ -586,7 +589,8 @@ cdef class ModelLikelihood(Likelihood):
         Parameters
         ----------
         species : numpy.ndarray
-            The default species value array, indexed as in `m`.
+            The default species value array, indexed as in the model
+            attached via `set_model`.
         """
         self.default_species = species
 

--- a/bioscrape/inference.pyx
+++ b/bioscrape/inference.pyx
@@ -1,3 +1,14 @@
+"""
+Bayesian parameter inference for bioscrape models.
+
+Provides `Data` (`BulkData`, `FlowData`, `StochasticTrajectories`) and
+`Likelihood` (`DeterministicLikelihood`, `StochasticTrajectoriesLikelihood`,
+`StochasticTrajectoryMomentLikelihood`, `StochasticStatesLikelihood`) class
+hierarchies for comparing simulated and experimental data, along with the
+user-facing `py_inference` entry point. See also
+`~bioscrape.pid_interfaces`, which wraps these classes into higher-level
+parameter identification interfaces.
+"""
 cimport numpy as np
 import numpy as np
 from libc.math cimport log
@@ -19,6 +30,14 @@ import emcee
 
 
 cdef class Distribution:
+    """
+    Base class for probability distributions used as priors.
+
+    Subclasses implement `unprob` (unnormalized probability), `prob`
+    (normalized probability), and `dim` (dimensionality); these are
+    `cdef` methods, called from Python via `py_unprob`, `py_prob`, and
+    `py_dim` below.
+    """
     cdef double unprob(self,np.ndarray a):
         raise NotImplementedError("Calling unprob() on Distribution")
     cdef double prob(self,np.ndarray a):
@@ -27,16 +46,60 @@ cdef class Distribution:
         raise NotImplementedError("Calling dim() on Distribution")
 
     def py_unprob(self, np.ndarray a):
+        """
+        Unnormalized probability of a point.
+
+        Parameters
+        ----------
+        a : numpy.ndarray
+            The point at which to evaluate the distribution.
+
+        Returns
+        -------
+        float
+            The unnormalized probability of `a`.
+        """
         return self.unprob(a)
 
     def py_prob(self, np.ndarray a):
+        """
+        Normalized probability of a point.
+
+        Parameters
+        ----------
+        a : numpy.ndarray
+            The point at which to evaluate the distribution.
+
+        Returns
+        -------
+        float
+            The normalized probability of `a`.
+        """
         return self.prob(a)
 
     def py_dim(self):
+        """
+        The dimensionality of the distribution.
+
+        Returns
+        -------
+        int
+            The number of dimensions.
+        """
         return self.dim()
 
 
 cdef class UniformDistribution(Distribution):
+    """
+    A uniform distribution over an axis-aligned box.
+
+    Parameters
+    ----------
+    lb : numpy.ndarray
+        The lower bound in each dimension.
+    ub : numpy.ndarray
+        The upper bound in each dimension; must be the same shape as `lb`.
+    """
     def __init__(self, np.ndarray lb, np.ndarray ub):
         self.dimension = lb.shape[0]
         self.lower_bounds = lb.copy()
@@ -78,10 +141,46 @@ cdef class UniformDistribution(Distribution):
 #################################################                     ################################################
 #Top level Data Object Class.
 cdef class Data():
+    """
+    Base class for experimental data used by a `Likelihood`.
+
+    Holds a set of measurements of `measured_species` at `timepoints`.
+    Subclasses (`BulkData`, `FlowData`, `StochasticTrajectories`) fix the
+    expected array shapes for a particular kind of experimental data; see
+    each subclass's `set_data` for its specific shape conventions.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray, optional
+        The time points at which the data was measured.
+    measurements : numpy.ndarray, optional
+        The measured values.
+    measured_species : list of str, optional
+        The names of the measured species.
+    N : int, optional
+        The number of samples/trajectories (default 1).
+    """
     def __init__(self, np.ndarray timepoints = None, np.ndarray measurements = None, list measured_species = [], unsigned N = 1):
         self.set_data(timepoints, measurements, measured_species, N)
 
     def set_data(self,np.ndarray timepoints, np.ndarray measurements, list measured_species, unsigned N):
+        """
+        Store `timepoints`, `measurements`, and `measured_species`.
+
+        Called by `__init__`; subclasses override this to validate and
+        reshape `measurements` according to their specific data layout.
+
+        Parameters
+        ----------
+        timepoints : numpy.ndarray
+            The time points at which the data was measured.
+        measurements : numpy.ndarray
+            The measured values.
+        measured_species : list of str
+            The names of the measured species.
+        N : int
+            The number of samples/trajectories.
+        """
         self.timepoints = timepoints
         self.measurements = measurements
         self.measured_species = measured_species
@@ -92,22 +191,75 @@ cdef class Data():
         return self.measurements
 
     def py_get_measurements(self):
+        """
+        The stored measurement array.
+
+        Returns
+        -------
+        numpy.ndarray
+            The measurements, in the shape set by `set_data`.
+        """
         return self.get_measurements()
 
     def py_get_timepoints(self):
+        """
+        The stored time points.
+
+        Returns
+        -------
+        numpy.ndarray
+            The time points at which the data was measured.
+        """
         return self.get_timepoints()
 
     def py_get_measured_species(self):
+        """
+        The names of the measured species.
+
+        Returns
+        -------
+        list of str
+            The measured species names.
+        """
         return self.get_measured_species
 
-#Data consists of a single timecourse at T points gathered across M measurements at timempoints timepoints. 
+#Data consists of a single timecourse at T points gathered across M measurements at timempoints timepoints.
 #Measurements are assumed to correspond to species names in measured_species.
 #Data Dimensions:
 # timepoints: T
 # Measurements: T x M
 # Measured Species: M
 cdef class BulkData(Data):
+    """
+    Bulk (deterministic-style) trajectory data.
+
+    `N` samples, each with measurements of `M` species at `T` time points.
+    `measurements` is reshaped to `(N, T, M)`. `timepoints` may be a single
+    length-`T` vector shared by all samples, or an `(N, T)` array giving each
+    sample its own time points.
+    """
     def set_data(self,np.ndarray timepoints, np.ndarray measurements, list measured_species, unsigned N):
+        """
+        Validate and store bulk trajectory data.
+
+        Parameters
+        ----------
+        timepoints : numpy.ndarray
+            A length-`T` vector (shared across samples) or, if `N > 1`, an
+            `(N, T)` array of per-sample time points.
+        measurements : numpy.ndarray
+            The measured values; reshaped to `(N, T, M)`.
+        measured_species : list of str
+            The names of the measured species.
+        N : int
+            The number of samples/trajectories.
+
+        Raises
+        ------
+        ValueError
+            If `N > 1` and the shapes of `timepoints` and `measurements` are
+            inconsistent with `N` samples.
+        """
         if N > 1:
             if timepoints.ndim == 1:
                 self.multiple_timepoints = False
@@ -127,11 +279,26 @@ cdef class BulkData(Data):
         self.measurements = np.reshape(measurements, (self.N, self.nT, self.M))
 
     def has_multiple_timepoints(self):
+        """
+        Whether each sample has its own time points.
+
+        Returns
+        -------
+        bool
+            True if `timepoints` was given as an `(N, T)` array (one vector
+            per sample), False if a single shared length-`T` vector was used.
+        """
         return self.multiple_timepoints
 
     def get_minimum_dt(self):
         """
-        Returns the minimum delta between measured timepoints
+        The minimum spacing between consecutive measured time points.
+
+        Returns
+        -------
+        float
+            The smallest gap between consecutive time points, across all
+            samples if `has_multiple_timepoints` is True.
         """
         if not self.multiple_timepoints:
             dt = self.timepoints[self.nT-1] - self.timepoints[0]
@@ -153,7 +320,35 @@ cdef class BulkData(Data):
 # Measurements: N x M
 # Measured Species: M
 cdef class FlowData(Data):
+    """
+    Flow-cytometry-style data.
+
+    `N` samples, each a single-timepoint measurement of `M` species. Unlike
+    `BulkData` and `StochasticTrajectories`, there is no time dimension --
+    `measurements` has shape `(N, M)`.
+    """
     def set_data(self,np.ndarray timepoints, np.ndarray measurements, list measured_species, unsigned N):
+        """
+        Validate and store flow data.
+
+        Parameters
+        ----------
+        timepoints : None
+            Must be None -- flow data is assumed to be collected at a
+            single, unspecified time point.
+        measurements : numpy.ndarray
+            The measured values, of shape `(N, M)`.
+        measured_species : list of str
+            The names of the measured species.
+        N : int
+            Unused; `N` is instead taken from `measurements.shape[0]`.
+
+        Raises
+        ------
+        ValueError
+            If `timepoints` is not None, or if the second dimension of
+            `measurements` does not match `len(measured_species)`.
+        """
         if timepoints is not None:
             raise ValueError("Flow Data is assumed to be collected at a single timepoint")
 
@@ -165,7 +360,7 @@ cdef class FlowData(Data):
         else:
             self.measurements = measurements
             self.N = measurements.shape[0]
-        
+
 
 #Data consists of a set of N stochastic trajectories at T timepoints which each contain measurements of M measured_species.
 #Data Dimensions:
@@ -173,15 +368,44 @@ cdef class FlowData(Data):
 # Measurements: N x T x M
 # Measured Species: M
 cdef class StochasticTrajectories(Data):
+    """
+    Single-cell stochastic trajectory data.
+
+    `N` trajectories, each with measurements of `M` species at `T` time
+    points. Unlike `BulkData`, `measurements` must always be given in full
+    `(N, T, M)` form (no implicit `N = 1` case).
+    """
 
     cdef  np.ndarray get_measurements(self):
         return np.reshape(self.measurements, (self.N, self.nT, self.M))
 
     def set_data(self, np.ndarray timepoints, np.ndarray measurements, list measured_species, unsigned N):
+        """
+        Validate and store stochastic trajectory data.
+
+        Parameters
+        ----------
+        timepoints : numpy.ndarray
+            A length-`T` vector (shared across trajectories) or an `(N, T)`
+            array of per-trajectory time points.
+        measurements : numpy.ndarray
+            The measured values, of shape `(N, T, M)`.
+        measured_species : list of str
+            The names of the measured species.
+        N : int
+            Unused; `N` is instead taken from `measurements.shape[0]`.
+
+        Raises
+        ------
+        ValueError
+            If the third dimension of `measurements` does not match
+            `len(measured_species)`, or if the shape of `timepoints` is
+            neither a single length-`T` vector nor an `(N, T)` array.
+        """
         self.measured_species = measured_species
         self.M = len(self.measured_species)
 
-        #if (self.M == 1 and measurements.ndim == 2) or (measurements.shape[2] == self.M): 
+        #if (self.M == 1 and measurements.ndim == 2) or (measurements.shape[2] == self.M):
         # ( M will always be shape N X T X M (instead of having a different shape of T X M for a single trajectory case ))
         if measurements.shape[2] == self.M:
             self.nT = measurements.shape[1]
@@ -201,6 +425,16 @@ cdef class StochasticTrajectories(Data):
             raise ValueError("timepoints must be a single vector of length T or N (# of samples) vectors each of length T")
 
     def has_multiple_timepoints(self):
+        """
+        Whether each trajectory has its own time points.
+
+        Returns
+        -------
+        bool
+            True if `timepoints` was given as an `(N, T)` array (one vector
+            per trajectory), False if a single shared length-`T` vector was
+            used.
+        """
         return self.multiple_timepoints
 
 ##################################################                ####################################################
@@ -208,13 +442,64 @@ cdef class StochasticTrajectories(Data):
 #################################################                     ################################################
 
 cdef class Likelihood:
+    """
+    Base class for log-likelihood functions.
+
+    Subclasses implement `get_log_likelihood` (a `cdef` method), called from
+    Python via `py_log_likelihood` below.
+    """
     cdef double get_log_likelihood(self):
         raise NotImplementedError("Calling get_log_likelihood() for Likelihood")
 
     def py_log_likelihood(self):
+        """
+        The log-likelihood of the currently-set model parameters and state.
+
+        Returns
+        -------
+        float
+            The log-likelihood value.
+        """
         return self.get_log_likelihood()
 
 cdef class ModelLikelihood(Likelihood):
+    """
+    Base class for likelihoods comparing model simulations to data.
+
+    Compares simulations of a `~bioscrape.types.Model` against a `Data`
+    object. Abstract: `set_likelihood_options` and `set_data` must be
+    implemented by subclasses (`DeterministicLikelihood`,
+    `StochasticTrajectoriesLikelihood`, `StochasticStatesLikelihood`).
+
+    Parameters
+    ----------
+    model : Model
+        The bioscrape model to simulate.
+    init_state : dict or list of dict, optional
+        Initial condition(s) for the simulated trajectories. A single dict
+        for one trajectory, or a list of dicts for multiple trajectories.
+    init_params : dict or list of dict, optional
+        Per-trajectory parameter overrides, in the same shape as
+        `init_state`.
+    interface : CSimInterface, optional
+        A pre-built simulation interface for `model`; built automatically if
+        not given.
+    simulator : RegularSimulator, optional
+        The simulator to use; the specific subclass chooses an appropriate
+        default (e.g. deterministic or stochastic) if not given.
+    data : Data, optional
+        The experimental data to compare simulations against. If not given,
+        `set_data` must be called separately before use.
+    **keywords
+        Additional keyword arguments, including `hmax` (maximum integrator
+        step size, deterministic simulation only) and `atol`/`rtol`
+        (absolute/relative integrator error tolerances).
+
+    Raises
+    ------
+    ValueError
+        If `init_state` is neither a dict nor a list of dicts.
+    """
     def __init__(self, model = None, init_state = {}, init_params = {},
                  interface = None, simulator = None, data = None,
                  **keywords):
@@ -267,6 +552,22 @@ cdef class ModelLikelihood(Likelihood):
             self.propagator.py_set_tolerance(atol, rtol)
 
     def set_model(self, Model m, RegularSimulator prop, CSimInterface csim = None, DelaySimulator prop_delay = None):
+        """
+        Attach a model, simulator, and simulation interface.
+
+        Parameters
+        ----------
+        m : Model
+            The bioscrape model to simulate.
+        prop : RegularSimulator
+            The simulator to use.
+        csim : CSimInterface, optional
+            A pre-built simulation interface for `m`; built automatically
+            with `~bioscrape.simulator.ModelCSimInterface` if not given.
+        prop_delay : DelaySimulator, optional
+            A delay-aware simulator, for subclasses that support delayed
+            reactions.
+        """
         if csim is None:
             self.csim = ModelCSimInterface(m)
         self.m = m
@@ -277,15 +578,46 @@ cdef class ModelLikelihood(Likelihood):
 
 
     def set_default_species(self, species):
+        """
+        Set the default species values.
+
+        Used to fill in unspecified initial conditions.
+
+        Parameters
+        ----------
+        species : numpy.ndarray
+            The default species value array, indexed as in `m`.
+        """
         self.default_species = species
-       
+
     def set_default_params(self, params):
+        """
+        Set (or update) the default parameter values.
+
+        Used to fill in unspecified per-trajectory parameter conditions.
+
+        Parameters
+        ----------
+        params : dict
+            Parameter name/value pairs. Merged into any existing defaults
+            rather than replacing them.
+        """
         if hasattr(self, "default_params"):
             self.default_params.update(params)
         else:
             self.default_params = dict(params)
 
     def set_init_species(self, list sds):
+        """
+        Set the initial species values for each trajectory.
+
+        Parameters
+        ----------
+        sds : list of dict
+            One dictionary of initial species values per trajectory (length
+            `self.Nx0`); species not given a value fall back to the default
+            set by `set_default_species`.
+        """
         self.initial_states = np.zeros((self.Nx0, self.m.get_number_of_species()))
         species2index = self.m.get_species2index()
         
@@ -298,7 +630,15 @@ cdef class ModelLikelihood(Likelihood):
                     self.initial_states[i, j] = self.default_species[j]
 
     def set_init_params(self, dict pd):
+        """
+        Set model parameter values for the current trajectory.
 
+        Parameters
+        ----------
+        pd : dict
+            Parameter name/value pairs to set on the model and simulation
+            interface.
+        """
         # print("before set", self.m.get_parameter_dictionary())
         # print("asking to be set to", pd)
         self.m.set_params(pd)
@@ -327,13 +667,65 @@ cdef class ModelLikelihood(Likelihood):
         return self.initial_parameters[n]
 
     def set_likelihood_options(self, **keywords):
+        """
+        Set likelihood-specific options.
+
+        Must be implemented by subclasses; see e.g.
+        `DeterministicLikelihood.set_likelihood_options`.
+
+        Parameters
+        ----------
+        **keywords
+            Subclass-specific option names and values.
+
+        Raises
+        ------
+        NotImplementedError
+            Always, unless overridden by a subclass.
+        """
         raise NotImplementedError("set_likelihood_options must be implemented in subclasses of ModelLikelihood")
 
     def set_data(self, **keywords):
+        """
+        Attach experimental data to compare simulations against.
+
+        Must be implemented by subclasses; see e.g.
+        `DeterministicLikelihood.set_data`.
+
+        Parameters
+        ----------
+        **keywords
+            Subclass-specific arguments (typically a single `Data` object).
+
+        Raises
+        ------
+        NotImplementedError
+            Always, unless overridden by a subclass.
+        """
         raise NotImplementedError("set_data must be implemented in subclasses of ModelLikelihood")
 
 cdef class DeterministicLikelihood(ModelLikelihood):
+    """
+    Log-likelihood of `BulkData` under deterministic simulation.
+
+    Compares deterministically-simulated trajectories to `BulkData` using a
+    `norm_order`-norm distance; see `set_likelihood_options`.
+    """
     def set_model(self, Model m, RegularSimulator prop = None, CSimInterface csim = None):
+        """
+        Attach a model, defaulting to a deterministic simulator.
+
+        Parameters
+        ----------
+        m : Model
+            The bioscrape model to simulate.
+        prop : RegularSimulator, optional
+            The simulator to use (default a new
+            `~bioscrape.simulator.DeterministicSimulator`).
+        csim : CSimInterface, optional
+            A pre-built simulation interface for `m`; built automatically if
+            not given.
+        """
         if prop is None:
             prop = DeterministicSimulator()
         ModelLikelihood.set_model(self, m, prop, csim)
@@ -342,13 +734,28 @@ cdef class DeterministicLikelihood(ModelLikelihood):
         #self.m = m
         #if csim is None:
         #    csim = ModelCSimInterface(m)
-        
+
         #self.csim = csim
-        
+
         #self.propagator = prop
 
 
     def set_data(self, BulkData bd):
+        """
+        Attach bulk trajectory data to compare simulations against.
+
+        Parameters
+        ----------
+        bd : BulkData
+            The experimental data.
+
+        Raises
+        ------
+        ValueError
+            If the number of samples in `bd` and the number of initial
+            conditions set via `set_init_species` are incompatible (neither
+            equal nor either equal to 1).
+        """
         #Set bulk data
         self.bd = bd
         self.N = self.bd.get_N() #Number of samples
@@ -368,15 +775,48 @@ cdef class DeterministicLikelihood(ModelLikelihood):
                              "initial conditions match or one of them must be 1")
 
     def py_get_data(self):
+        """
+        The attached data.
+
+        Returns
+        -------
+        BulkData
+            The data set by `set_data`.
+        """
         return self.bd
 
     def set_likelihood_options(self, norm_order = 1, **keywords):
+        """
+        Set the norm order used to compare trajectories.
+
+        Parameters
+        ----------
+        norm_order : int, optional
+            The order of the norm used in the log-likelihood distance
+            (default 1).
+        """
         self.norm_order = norm_order
 
     def py_get_norm_order(self):
+        """
+        The norm order used to compare trajectories.
+
+        Returns
+        -------
+        int
+            The norm order set by `set_likelihood_options`.
+        """
         return self.norm_order
 
     def py_set_hmax(self, hmax):
+        """
+        Set the integrator's maximum step size.
+
+        Parameters
+        ----------
+        hmax : float
+            The maximum step size for the deterministic integrator.
+        """
         self.hmax = hmax
         self.propagator.py_set_hmax(hmax)
 
@@ -431,7 +871,34 @@ cdef class DeterministicLikelihood(ModelLikelihood):
             return -error
 
 cdef class StochasticTrajectoriesLikelihood(ModelLikelihood):
+    """
+    Log-likelihood of `StochasticTrajectories` data.
+
+    Compares the average of `N_simulations` stochastic simulations per
+    trajectory to `StochasticTrajectories` data using a `norm_order`-norm
+    distance; see `set_likelihood_options`.
+    """
     def set_model(self, Model m, RegularSimulator prop = None, CSimInterface csim = None, DelaySimulator prop_delay = None):
+        """
+        Attach a model, defaulting to an SSA-based simulator.
+
+        Defaults to `~bioscrape.simulator.SSASimulator`, or a
+        `~bioscrape.simulator.DelaySSASimulator` if `m` has delayed
+        reactions.
+
+        Parameters
+        ----------
+        m : Model
+            The bioscrape model to simulate.
+        prop : RegularSimulator, optional
+            The simulator to use; chosen automatically based on
+            `m.has_delay` if not given.
+        csim : CSimInterface, optional
+            A pre-built simulation interface for `m`; built automatically if
+            not given.
+        prop_delay : DelaySimulator, optional
+            The delay-aware simulator to use if `m` has delayed reactions.
+        """
         if prop is None:
             if m.has_delay:
                 prop = DelaySSASimulator()
@@ -452,7 +919,21 @@ cdef class StochasticTrajectoriesLikelihood(ModelLikelihood):
         #self.csim = csim
 
     def set_data(self, StochasticTrajectories sd):
+        """
+        Attach stochastic trajectory data to compare simulations against.
 
+        Parameters
+        ----------
+        sd : StochasticTrajectories
+            The experimental data.
+
+        Raises
+        ------
+        ValueError
+            If the number of samples in `sd` and the number of initial
+            conditions set via `set_init_species` are incompatible (neither
+            equal nor either equal to 1).
+        """
         self.sd = sd #Holds Data Object
         self.N = sd.get_N() #Number of samples
 
@@ -472,9 +953,29 @@ cdef class StochasticTrajectoriesLikelihood(ModelLikelihood):
             raise ValueError("Either the number of samples and the number of"
                              "initial conditions match or one of them must be 1")
     def py_get_data(self):
+        """
+        The attached data.
+
+        Returns
+        -------
+        StochasticTrajectories
+            The data set by `set_data`.
+        """
         return self.sd
 
     def set_likelihood_options(self, N_simulations = None, norm_order = None, **keywords):
+        """
+        Set the number of repeated simulations and the norm order.
+
+        Parameters
+        ----------
+        N_simulations : int, optional
+            The number of stochastic simulations to average per trajectory
+            (default 1).
+        norm_order : int, optional
+            The order of the norm used in the log-likelihood distance
+            (default 1).
+        """
         if norm_order is not None:
             self.norm_order = norm_order
         if norm_order in [None, 0]:
@@ -486,8 +987,24 @@ cdef class StochasticTrajectoriesLikelihood(ModelLikelihood):
             self.N_simulations = 1
 
     def py_get_N_simulations(self):
+        """
+        The number of repeated simulations averaged per trajectory.
+
+        Returns
+        -------
+        int
+            The value set by `set_likelihood_options`.
+        """
         return self.N_simulations
     def py_get_norm_order(self):
+        """
+        The norm order used to compare trajectories.
+
+        Returns
+        -------
+        int
+            The value set by `set_likelihood_options`.
+        """
         return self.norm_order
 
     cdef double get_log_likelihood(self):
@@ -541,7 +1058,34 @@ cdef class StochasticTrajectoriesLikelihood(ModelLikelihood):
             return error
 
 cdef class StochasticTrajectoryMomentLikelihood(StochasticTrajectoriesLikelihood):
+    """
+    `StochasticTrajectoriesLikelihood` with moment-matching options.
+
+    Adds `initial_state_matching` and `Moments` options to
+    `set_likelihood_options`; the log-likelihood computation itself is
+    inherited unchanged from `StochasticTrajectoriesLikelihood`.
+    """
     def set_likelihood_options(self, N_simulations = 1, initial_state_matching = False, Moments = 2, **keywords):
+        """
+        Set the moment-matching options for this likelihood.
+
+        Parameters
+        ----------
+        N_simulations : int, optional
+            Present for interface compatibility with
+            `StochasticTrajectoriesLikelihood.set_likelihood_options`;
+            always set to 1 regardless of the value passed.
+        initial_state_matching : bool, optional
+            Stored for use by subclasses (default False).
+        Moments : int, optional
+            The number of moments to match: 1 (averages) or 2 (averages and
+            second moments); default 2.
+
+        Raises
+        ------
+        ValueError
+            If `Moments` is greater than 2.
+        """
         self.N_simulations = 1
         self.initial_state_matching = initial_state_matching
         if Moments > 2:
@@ -549,7 +1093,33 @@ cdef class StochasticTrajectoryMomentLikelihood(StochasticTrajectoriesLikelihood
         self.Moments = Moments
 
 cdef class StochasticStatesLikelihood(ModelLikelihood):
+    """
+    Log-likelihood of `FlowData` under stochastic simulation.
+
+    Compares single-timepoint state distributions from stochastic
+    simulation against `FlowData`.
+    """
     def set_model(self, Model m, RegularSimulator prop = None, CSimInterface csim = None, DelaySimulator prop_delay = None):
+        """
+        Attach a model, defaulting to an SSA-based simulator.
+
+        Defaults to `~bioscrape.simulator.SSASimulator`, or a
+        `~bioscrape.simulator.DelaySSASimulator` if `m` has delayed
+        reactions.
+
+        Parameters
+        ----------
+        m : Model
+            The bioscrape model to simulate.
+        prop : RegularSimulator, optional
+            The simulator to use; chosen automatically based on
+            `m.has_delay` if not given.
+        csim : CSimInterface, optional
+            A pre-built simulation interface for `m`; built automatically if
+            not given.
+        prop_delay : DelaySimulator, optional
+            The delay-aware simulator to use if `m` has delayed reactions.
+        """
         self.m = m
 
         if csim is None:
@@ -568,6 +1138,14 @@ cdef class StochasticStatesLikelihood(ModelLikelihood):
         self.csim = csim
 
     def set_data(self, FlowData fd):
+        """
+        Attach flow data to compare simulations against.
+
+        Parameters
+        ----------
+        fd : FlowData
+            The experimental data.
+        """
         self.fd = fd
         the_list = fd.get_measured_species()
         self.meas_indices = np.zeros(len(the_list), dtype=int)
@@ -580,56 +1158,76 @@ def py_inference(Model = None, params_to_estimate = None, exp_data = None, initi
                  nsteps = None, init_seed = None, prior = None, sim_type = None, inference_type = 'emcee',
                  method = 'mcmc', plot_show = True, parallel = None, **kwargs):
     """
-    User level interface for running bioscrape inference module.
-    Args:
-        Model (bioscrape.types.Model): Bioscrape Model object 
-        params_to_estimate (List[str]): A list of parameter names in the Model to estimate
-        exp_data (List[pd.DataFrame], pd.Dataframe): A pandas.DataFrame or a list of pandas.Dataframe 
-                                                     that consists of the required experimental data\
-        initial_conditions (List[dict], dict): A list of dictionaries of initial conditions corresponding to each
-                                               data trajectory in exp_data or a single dictionary if one trajectory
-        parameter_conditions (List[dict], dict): A list of dictionaries of parameter conditions corresponding to each
-                                                 data trajectory in exp_data or a single dictionary if one trajectory
-        measurements (List[str], str): Names of species in the Model that are measured, either as a list if multiple outputs
-                                       or a single measurement.
-        time_column (str): The column name of the exp_data that contains the time points in the data, for time-series inference
-        nwalkers (int): The number of walkers for the Markov Chain Monte Carlo sampling. See emcee.EnsembleSampler for more info.
-        nsteps (int): The number of steps for the Markov Chain Monte Carlo sampling. See emcee.EnsembleSampler for more info.
-        init_seed (Union[float, np.ndarray, list. "prior"]): The parameter that controls the initial parameter 
-                                                             values for the sampling.
-                                                             If a float "r" is passed, then the initial values 
-                                                             are sampled from a Gaussian ball of radius "r" around mean values
-                                                             set as Model parameter values
-                                                             If a np.ndarray or a list is passed, then the length must be same 
-                                                             as the number of `params_to_estimate`. These values are then 
-                                                             used as initial values for the sampler.
-                                                             If the keyword "prior" is passed, then the initial values are sampled
-                                                             from the prior distributions specified for each parameter value.
-        prior (dict): The prior dict specifies the prior for each parameter in params_to_estimate. The syntax is
-                      {"parameter1": ["uniform", min_value, max_value],
-                       "parameter2": ["gaussian", mean, std, "positive"]}
-                       The "positive" keyword ensures that the prior rejects all negative values for the parameter.
-                       Refer to the full documentation on priors on our Wiki: https://github.com/biocircuits/bioscrape/wiki
-        sim_type (Union["deterministic", "stochastic"]): A str that is either "deterministic" or "stochastic" to set the
-                                                         type of simulation for the inference run.
-        inference_type (Union["emcee", "lmfit"]): A str that specifies the kind of inference to run. Currently, only two packages 
-                                                  are supported: emcee and lmfit.
-        method (str): For inference_type = emcee, this argument should not be used. For lmfit, method is passed into the method
-                      keyword of the lmfit call. More details here: 
-                      https://lmfit.github.io/lmfit-py/fitting.html#choosing-different-fitting-methods
-        plot_show (bool): If set to `True`, bioscrape will try to display the generated plots from the inference run. 
-                          If set to `False`, not plots will be shown.
-        parallel (bool): If set to `True`, bioscrape will create a multiprocessing.Pool object 
-                         and will be passed to emcee.EnsembleSampler for parallel
-                         processing. If set to `False`, multiprocessing will not be used.
-        kwargs: Additional keyword arguments that are passed into the inference setup.
-    Returns:
-        for inference_type = "emcee":
-            sampler, pid: A tuple consisting of the emcee.EnsembleSampler and the bioscrape pid object
-        for inference_type = "lmfit":
-            minimizer_result: A lmfit.MinimizerResult object that consists of the minimizer information.
-    Raises:
-        ValueError: When `inference_type` argument is set to something other than the currently supported modules.
+    User-level interface for Bayesian parameter inference.
+
+    Parameters
+    ----------
+    Model : Model
+        The bioscrape model to fit.
+    params_to_estimate : list of str
+        The names of the parameters in `Model` to estimate.
+    exp_data : pandas.DataFrame or list of pandas.DataFrame
+        The experimental data to fit against.
+    initial_conditions : dict or list of dict, optional
+        Initial condition(s) for the simulated trajectories, in the same
+        shape as `exp_data`. Defaults to the model's own initial conditions.
+    parameter_conditions : dict or list of dict, optional
+        Per-trajectory parameter overrides, in the same shape as `exp_data`.
+    measurements : list of str or str, optional
+        The name(s) of the species in `Model` that are measured.
+    time_column : str, optional
+        The column name in `exp_data` that holds the time points, for
+        time-series inference.
+    nwalkers : int, optional
+        The number of walkers for MCMC sampling; see
+        `emcee.EnsembleSampler`.
+    nsteps : int, optional
+        The number of steps for MCMC sampling; see `emcee.EnsembleSampler`.
+    init_seed : float or numpy.ndarray or list or 'prior', optional
+        Controls the initial parameter values for the sampler. A float `r`
+        samples initial values from a Gaussian ball of radius `r` around
+        the model's parameter values; an array or list of length
+        `len(params_to_estimate)` is used directly as the initial values;
+        'prior' samples the initial values from `prior`.
+    prior : dict, optional
+        The prior for each parameter in `params_to_estimate`. For example::
+
+            {'parameter1': ['uniform', min_value, max_value],
+             'parameter2': ['gaussian', mean, std, 'positive']}
+
+        The 'positive' flag rejects negative parameter values. See the
+        `bioscrape wiki <https://github.com/biocircuits/bioscrape/wiki>`_
+        for the full list of supported priors.
+    sim_type : {'deterministic', 'stochastic'}, optional
+        The type of simulation to use for the inference run.
+    inference_type : {'emcee', 'lmfit'}, optional
+        The inference package to use (default 'emcee').
+    method : str, optional
+        Ignored for `inference_type='emcee'`. For `inference_type='lmfit'`,
+        passed as the `method` keyword to `lmfit.minimize`; see the
+        `lmfit docs <https://lmfit.github.io/lmfit-py/fitting.html>`_.
+    plot_show : bool, optional
+        If True, display the plots generated by the inference run (default
+        True).
+    parallel : bool, optional
+        If True, run the sampler with a `multiprocessing.Pool` passed to
+        `emcee.EnsembleSampler` for parallel processing. If False (default),
+        multiprocessing is not used.
+    **kwargs
+        Additional keyword arguments passed into the inference setup.
+
+    Returns
+    -------
+    tuple or lmfit.minimizer.MinimizerResult
+        For `inference_type='emcee'`: a tuple `(sampler, pid)` of the
+        `emcee.EnsembleSampler` and the bioscrape PID object. For
+        `inference_type='lmfit'`: an `lmfit.minimizer.MinimizerResult`.
+
+    Raises
+    ------
+    ValueError
+        If `Model` is None, or if `inference_type` is not one of the
+        supported values ('emcee', 'lmfit').
     """
     if Model is None:
         raise ValueError('Model object cannot be None.')

--- a/bioscrape/inference_setup.py
+++ b/bioscrape/inference_setup.py
@@ -250,9 +250,9 @@ class InferenceSetup(object):
         Parameters
         ----------
         prior : dict
-            Maps each parameter name in `params_to_estimate` to a list
-            describing its prior distribution; see :doc:`../inference`
-            for the supported prior types.
+            Maps each parameter name in `self.params_to_estimate` to a
+            list describing its prior distribution; see
+            :doc:`../inference` for the supported prior types.
 
         Returns
         -------
@@ -263,7 +263,7 @@ class InferenceSetup(object):
         ------
         ValueError
             If `prior` does not have exactly one entry per parameter
-            in `params_to_estimate`.
+            in `self.params_to_estimate`.
         """
         self.prior = prior
         if len(list(self.prior.keys())) != len(self.params_to_estimate):
@@ -345,7 +345,7 @@ class InferenceSetup(object):
         """
         Force the timepoints to use for inference.
 
-        By default, the timepoints are extracted from `exp_data`.
+        By default, the timepoints are extracted from `self.exp_data`.
 
         Parameters
         ----------
@@ -367,7 +367,8 @@ class InferenceSetup(object):
         Parameters
         ----------
         params_to_estimate : list of str
-            The names of the parameters in `Model` to estimate.
+            The names of the parameters in the model (attached via
+            `set_model`) to estimate.
 
         Returns
         -------
@@ -418,7 +419,7 @@ class InferenceSetup(object):
         """
         Set the number of stochastic simulations averaged per data point.
 
-        Only applies when `sim_type` is 'stochastic'.
+        Only applies when `self.sim_type` is 'stochastic'.
 
         Parameters
         ----------
@@ -428,8 +429,8 @@ class InferenceSetup(object):
         Returns
         -------
         bool or None
-            True if set; otherwise None, with a warning, if `sim_type`
-            is not 'stochastic'.
+            True if set; otherwise None, with a warning, if
+            `self.sim_type` is not 'stochastic'.
         """
         if self.sim_type == 'stochastic':
             self.N_simulations = N_simulations
@@ -446,8 +447,8 @@ class InferenceSetup(object):
         initial_conditions : dict or list of dict
             A dictionary mapping species names to initial values, or a
             list of such dictionaries (one per trajectory in
-            `exp_data`, in the same order). If None, defaults to
-            `Model`'s own initial conditions.
+            `self.exp_data`, in the same order). If None, defaults to
+            the model's own initial conditions (see `set_model`).
 
         Returns
         -------
@@ -480,7 +481,8 @@ class InferenceSetup(object):
         parameter_conditions : dict or list of dict
             A dictionary mapping parameter names (that change between
             measurements) to values, or a list of such dictionaries
-            (one per trajectory in `exp_data`, in the same order).
+            (one per trajectory in `self.exp_data`, in the same
+            order).
 
         Returns
         -------
@@ -493,12 +495,13 @@ class InferenceSetup(object):
 
     def set_measurements(self, measurements: list):
         """
-        Set the list of measured species to look for in `exp_data`.
+        Set the list of measured species to look for in `self.exp_data`.
 
         Parameters
         ----------
         measurements : list of str
-            The name(s) of the species in `Model` that are measured.
+            The name(s) of the species in the model (attached via
+            `set_model`) that are measured.
 
         Returns
         -------
@@ -510,12 +513,13 @@ class InferenceSetup(object):
 
     def set_time_column(self, time_column: str):
         """
-        Set the name of the time column in `exp_data`.
+        Set the name of the time column in `self.exp_data`.
 
         Parameters
         ----------
         time_column : str
-            The column name in `exp_data` that holds the time points.
+            The column name in `self.exp_data` that holds the time
+            points.
 
         Returns
         -------
@@ -592,7 +596,8 @@ class InferenceSetup(object):
         Returns
         -------
         list of str
-            The names of the parameters in `Model` to estimate.
+            The names of the parameters in the model (attached via
+            `set_model`) to estimate.
         """
         return self.params_to_estimate
 
@@ -602,7 +607,7 @@ class InferenceSetup(object):
 
         Prepares the inference (extracting data, setting up the
         likelihood) and then runs `emcee.EnsembleSampler` for
-        `nsteps` steps with `nwalkers` walkers.
+        `self.nsteps` steps with `self.nwalkers` walkers.
 
         Parameters
         ----------
@@ -647,7 +652,7 @@ class InferenceSetup(object):
         Returns
         -------
         emcee.EnsembleSampler
-            The sampler, after running `nsteps` steps.
+            The sampler, after running `self.nsteps` steps.
         """
         self.prepare_inference(**kwargs)
         sampler = self.run_emcee(**kwargs)
@@ -659,7 +664,8 @@ class InferenceSetup(object):
 
         Applies any of the `timepoints`/`norm_order`/`N_simulations`/
         `debug` keyword arguments given, then prepares the initial and
-        parameter conditions and extracts `exp_data` into `LL_data`.
+        parameter conditions and extracts `self.exp_data` into
+        `self.LL_data`.
 
         Parameters
         ----------
@@ -704,13 +710,13 @@ class InferenceSetup(object):
 
     def prepare_initial_conditions(self):
         """
-        Expand `initial_conditions` to one dict per trajectory in `exp_data`.
+        Expand `self.initial_conditions` to one dict per trajectory.
 
         Raises
         ------
         ValueError
-            If `initial_conditions` is a list whose length does not
-            match the number of trajectories in `exp_data`.
+            If `self.initial_conditions` is a list whose length does not
+            match the number of trajectories in `self.exp_data`.
         """
         # Create initial conditions as required
         N = 1 if type(self.exp_data) is dict else len(self.exp_data)
@@ -728,16 +734,16 @@ class InferenceSetup(object):
 
     def prepare_parameter_conditions(self):
         """
-        Expand `parameter_conditions` to one dict per trajectory in `exp_data`.
+        Expand `self.parameter_conditions` to one dict per trajectory.
 
         Raises
         ------
         ValueError
-            If `parameter_conditions` is a list whose length does not
-            match the number of trajectories in `exp_data`.
+            If `self.parameter_conditions` is a list whose length does
+            not match the number of trajectories in `self.exp_data`.
         AssertionError
-            If a parameter in `params_to_estimate` also appears in a
-            per-trajectory parameter condition.
+            If a parameter in `self.params_to_estimate` also appears
+            in a per-trajectory parameter condition.
         """
         # Create parameter conditions as required
         N = 1 if type(self.exp_data) is dict else len(self.exp_data)
@@ -763,11 +769,11 @@ class InferenceSetup(object):
 
     def extract_data(self):
         """
-        Reshape `exp_data` into a single `(N, T, M)` array.
+        Reshape `self.exp_data` into a single `(N, T, M)` array.
 
-        Extracts the timepoints (from `time_column`) and measured
-        species (from `measurements`) from `exp_data`, which may be a
-        single `pandas.DataFrame` or a list of them (one per
+        Extracts the timepoints (from `self.time_column`) and measured
+        species (from `self.measurements`) from `self.exp_data`, which
+        may be a single `pandas.DataFrame` or a list of them (one per
         trajectory), into one array of measurements indexed by
         trajectory, timepoint, and measured species.
 
@@ -780,9 +786,10 @@ class InferenceSetup(object):
         Raises
         ------
         TypeError
-            If `time_column` is not set, if `exp_data` (or one of its
-            entries, when a list) is not a `pandas.DataFrame`, or if
-            `exp_data` is of an unrecognized type.
+            If `self.time_column` is not set, if `self.exp_data` (or
+            one of its entries, when a list) is not a
+            `pandas.DataFrame`, or if `self.exp_data` is of an
+            unrecognized type.
         """
         exp_data = self.exp_data
         # Get timepoints from given experimental data
@@ -859,12 +866,13 @@ class InferenceSetup(object):
 
     def setup_cost_function(self, **kwargs):
         """
-        Build the `PIDInterface`-derived likelihood object for `sim_type`.
+        Build the `PIDInterface`-derived likelihood for `self.sim_type`.
 
         Constructs a `~bioscrape.pid_interfaces.StochasticInference` or
         `~bioscrape.pid_interfaces.DeterministicInference` (depending
-        on `sim_type`), and sets it up against `LL_data`. Stores the
-        result as `pid_interface`, used by `cost_function`.
+        on `self.sim_type`), and sets it up against `self.LL_data`.
+        Stores the result as `self.pid_interface`, used by
+        `cost_function`.
 
         Parameters
         ----------
@@ -890,14 +898,15 @@ class InferenceSetup(object):
         """
         The log-likelihood of `params`, for use as an MCMC cost function.
 
-        Evaluates `pid_interface`'s likelihood at `params`, and records
-        both the value and `params` (in `cost_progress`/`cost_params`)
-        for later inspection.
+        Evaluates `self.pid_interface`'s likelihood at `params`, and
+        records both the value and `params` (in `self.cost_progress`/
+        `self.cost_params`) for later inspection.
 
         Parameters
         ----------
         params : array_like
-            The parameter values, in the order of `params_to_estimate`.
+            The parameter values, in the order of
+            `self.params_to_estimate`.
 
         Returns
         -------
@@ -921,7 +930,7 @@ class InferenceSetup(object):
         """
         Sample the initial parameter values for each MCMC walker.
 
-        Uses `init_seed` (optionally overridden by the `init_seed`
+        Uses `self.init_seed` (optionally overridden by the `init_seed`
         keyword argument) to determine the initial values; see the
         class docstring for the supported forms. Values whose prior
         has a 'positive' flag are clipped to be non-negative (or a
@@ -935,8 +944,8 @@ class InferenceSetup(object):
         Returns
         -------
         numpy.ndarray
-            Array of shape `(nwalkers, len(params_to_estimate))` giving
-            the initial parameter values for each walker.
+            Array of shape `(self.nwalkers, len(self.params_to_estimate))`
+            giving the initial parameter values for each walker.
 
         Raises
         ------
@@ -1026,14 +1035,14 @@ class InferenceSetup(object):
         Returns
         -------
         emcee.EnsembleSampler
-            The sampler, after running `nsteps` steps.
+            The sampler, after running `self.nsteps` steps.
 
         Raises
         ------
         ImportError
             If the `emcee` package is not installed, or if
-            `parallel` is True and the `multiprocessing` package is
-            not available.
+            `self.parallel` is True and the `multiprocessing` package
+            is not available.
         """
         if kwargs.get("reuse_likelihood", False) is False:
             self.setup_cost_function(**kwargs)
@@ -1119,11 +1128,11 @@ class InferenceSetup(object):
             Passed to `matplotlib.pyplot.subplots` for the chain plot.
         labels : list of str, optional
             Axis labels for each parameter; defaults to
-            `params_to_estimate`.
+            `self.params_to_estimate`.
         alpha : float, default 0.3
             Transparency of the individual walker traces in the chain
             plot.
-        discard : int, default `2 * nwalkers`
+        discard : int, default `2 * self.nwalkers`
             Number of initial steps to discard as burn-in before
             computing the posterior summary and corner plot.
         thin : int, default 1
@@ -1203,7 +1212,7 @@ class InferenceSetup(object):
         """
         Run least-squares parameter inference via `lmfit`.
 
-        Fits each trajectory in `exp_data` independently with
+        Fits each trajectory in `self.exp_data` independently with
         `lmfit.minimize`, using `~bioscrape.pid_interfaces.LMFitInference`.
 
         Parameters
@@ -1219,7 +1228,7 @@ class InferenceSetup(object):
         Returns
         -------
         list of lmfit.minimizer.MinimizerResult
-            One result per trajectory in `exp_data`.
+            One result per trajectory in `self.exp_data`.
         """
         self.prepare_inference(**kwargs)
         N = np.shape(self.LL_data)[0]

--- a/bioscrape/inference_setup.py
+++ b/bioscrape/inference_setup.py
@@ -1,3 +1,16 @@
+"""
+Orchestrates Bayesian and least-squares parameter inference for
+bioscrape models.
+
+`InferenceSetup` wraps `emcee <https://emcee.readthedocs.io/>`_
+(Bayesian/MCMC) and `lmfit <https://lmfit.github.io/lmfit-py/>`_
+(least-squares) inference around a `~bioscrape.types.Model`, using the
+`~bioscrape.pid_interfaces.PIDInterface` subclasses to build the
+likelihood being sampled or minimized. Most users should use the
+higher-level `~bioscrape.inference.py_inference` entry point, which
+constructs an `InferenceSetup` and returns it (along with the `emcee`
+sampler) rather than requiring one to be built directly.
+"""
 import numpy as np
 import warnings
 try:
@@ -12,10 +25,107 @@ from bioscrape.simulator import ModelCSimInterface, DeterministicSimulator, SSAS
 from bioscrape.pid_interfaces import *
 
 def initialize_inference(**kwargs):
+    """
+    Construct an `InferenceSetup`.
+
+    Parameters
+    ----------
+    **kwargs
+        Forwarded to `InferenceSetup`.
+
+    Returns
+    -------
+    InferenceSetup
+        The constructed inference object.
+    """
     return InferenceSetup(**kwargs)
 
 class InferenceSetup(object):
+    """
+    Sets up and runs parameter inference for a bioscrape model.
+
+    Constructed (and returned) by `~bioscrape.inference.py_inference`;
+    most users will not need to construct this directly. Holds the
+    model, data, prior, and inference settings, and provides `run_mcmc`
+    (Bayesian inference via `emcee`) and `run_lmfit` (least-squares fit
+    via `lmfit`) to actually perform the inference.
+
+    Parameters
+    ----------
+    Model : Model, optional
+        The bioscrape model to fit.
+    params_to_estimate : list of str, optional
+        The names of the parameters in `Model` to estimate.
+    exp_data : pandas.DataFrame or list of pandas.DataFrame, optional
+        The experimental data to fit against.
+    prior : dict, optional
+        The prior for each parameter in `params_to_estimate`; see
+        `set_prior`.
+    measurements : list of str, optional
+        The name(s) of the species in `Model` that are measured
+        (default `['']`).
+    time_column : str, default 'time'
+        The column name in `exp_data` that holds the time points.
+    timepoints : list or numpy.ndarray, optional
+        Force the timepoints used for inference, instead of extracting
+        them from `exp_data`.
+    initial_conditions : dict or list of dict, optional
+        Initial condition(s) for the simulated trajectories, in the
+        same shape as `exp_data`. Defaults to `Model`'s own initial
+        conditions.
+    parameter_conditions : dict or list of dict, optional
+        Per-trajectory parameter overrides, in the same shape as
+        `exp_data`.
+    sim_type : {'deterministic', 'stochastic'}, default 'deterministic'
+        The type of simulation to use for the inference run.
+    method : {'emcee', 'lmfit'}, default 'emcee'
+        The inference package to use; see `set_method`.
+    nwalkers : int, default 100
+        The number of walkers for MCMC sampling; see
+        `emcee.EnsembleSampler`.
+    nsteps : int, default 1000
+        The number of steps for MCMC sampling; see
+        `emcee.EnsembleSampler`.
+    init_seed : float or numpy.ndarray or list or 'prior', default 0.01
+        Controls the initial parameter values for the MCMC sampler. A
+        float `r` samples initial values from a Gaussian ball of
+        radius `r` around the model's parameter values; an array or
+        list of length `len(params_to_estimate)` is used directly as
+        the initial values; 'prior' samples the initial values from
+        `prior`.
+    norm_order : int, default 2
+        The norm used to compute the log-likelihood distance between
+        simulated and measured trajectories; see
+        `~bioscrape.inference.StochasticTrajectoriesLikelihood`.
+    N_simulations : int, default 3
+        The number of stochastic simulations to average per data point
+        when `sim_type='stochastic'`.
+    parallel : bool, default False
+        If True, run MCMC sampling with a `multiprocessing.Pool`.
+    debug : bool, default False
+        If True, print verbose diagnostic messages while preparing and
+        running inference.
+    dimension : int, default 1
+        Stored on the object but not currently used elsewhere.
+    hmax : float, optional
+        Stored on the object but not currently used elsewhere.
+
+    Attributes
+    ----------
+    LL_data : numpy.ndarray
+        The experimental data reshaped to `(N, T, M)` (trajectories by
+        timepoints by measured species) by `extract_data`; set when
+        `exp_data` is given at construction, or by `prepare_inference`.
+    cost_progress : list
+        The log-likelihood value computed at each `cost_function` call
+        during a `run_mcmc`/`run_emcee` run.
+    cost_params : list
+        The parameter values passed to `cost_function` at each call
+        during a `run_mcmc`/`run_emcee` run, in the same order as
+        `cost_progress`.
+    """
     def __init__(self, **kwargs):
+        """See class docstring."""
         self.M = None
         self.M = kwargs.get('Model', None)
         self.params_to_estimate = kwargs.get('params_to_estimate', [])
@@ -44,10 +154,11 @@ class InferenceSetup(object):
         if self.exp_data is not None:
             self.prepare_inference()
             self.setup_cost_function()
-        return 
+        return
 
     #Whenever new settings are updated in the constructor, please add them to getstate and setstate
     def __getstate__(self):
+        """Return this object's state as a tuple of picklable objects."""
         return (
             self.M,
             self.params_to_estimate,
@@ -75,7 +186,7 @@ class InferenceSetup(object):
             )
 
     def __setstate__(self, state):
-       
+        """Restore this object's state from a tuple produced by `__getstate__`."""
         self.M = state[0]
         self.params_to_estimate = state[1]
         self.init_seed = state[2]
@@ -102,110 +213,255 @@ class InferenceSetup(object):
         if self.exp_data is not None:
             self.prepare_inference()
             self.setup_cost_function()
-            
+
 
     def set_model(self, M):
-        '''
-        Set the bioscrape Model to the inference object
-        '''
+        """
+        Set the bioscrape model to fit.
+
+        Parameters
+        ----------
+        M : Model
+            The bioscrape model to fit.
+
+        Returns
+        -------
+        bool
+            True.
+        """
         self.M = M
         return True
 
     def get_model(self):
-        '''
-        Get the bioscrape Model for the inference object
-        '''
-        return self.M 
+        """
+        The bioscrape model being fit.
+
+        Returns
+        -------
+        Model
+            The bioscrape model to fit.
+        """
+        return self.M
 
     def set_prior(self, prior):
-        '''
-        Set the prior distribution for the parameter inference
-        '''
+        """
+        Set the prior distribution for each parameter to estimate.
+
+        Parameters
+        ----------
+        prior : dict
+            Maps each parameter name in `params_to_estimate` to a list
+            describing its prior distribution; see :doc:`../inference`
+            for the supported prior types.
+
+        Returns
+        -------
+        bool
+            True.
+
+        Raises
+        ------
+        ValueError
+            If `prior` does not have exactly one entry per parameter
+            in `params_to_estimate`.
+        """
         self.prior = prior
         if len(list(self.prior.keys())) != len(self.params_to_estimate):
             raise ValueError('Prior keys length must be equal to the length of params_to_estimate.')
-        return True 
+        return True
 
     def set_nsteps(self, nsteps: int):
-        '''
-        Set the nsteps for the parameter inference using emcee
-        '''
-        self.nsteps = nsteps 
-        return True 
-        
+        """
+        Set the number of MCMC steps to run.
+
+        Parameters
+        ----------
+        nsteps : int
+            The number of steps for MCMC sampling; see
+            `emcee.EnsembleSampler`.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.nsteps = nsteps
+        return True
+
     def set_nwalkers(self, nwalkers: int):
-        '''
-        Set the number of walkers for the parameter inference using emcee
-        '''
-        self.nwalkers = nwalkers 
-        return True 
+        """
+        Set the number of MCMC walkers to use.
+
+        Parameters
+        ----------
+        nwalkers : int
+            The number of walkers for MCMC sampling; see
+            `emcee.EnsembleSampler`.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.nwalkers = nwalkers
+        return True
 
     def set_dimension(self, dimension: int):
-        '''
-        Set the dimension of parameter set to identify 
-        '''
-        self.dimension = dimension 
-        return True 
+        """
+        Set the `dimension` attribute.
+
+        Parameters
+        ----------
+        dimension : int
+            Stored on the object but not currently used elsewhere.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.dimension = dimension
+        return True
 
     def set_init_seed(self, init_seed: float):
-        '''
-        Set the init_seed of parameter set to initialize the parameter identification routine
-        '''
-        self.init_seed = init_seed 
-        return True 
+        """
+        Set the initial parameter values for the MCMC sampler.
+
+        Parameters
+        ----------
+        init_seed : float or numpy.ndarray or list or 'prior'
+            Controls the initial parameter values for the sampler; see
+            the class docstring.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.init_seed = init_seed
+        return True
 
     def set_timepoints(self, timepoints):
-        '''
-        Set (force) the timepoints to use for parameter inference. By default, the time points are loaded in from exp_data
-        '''
-        self.timepoints = timepoints 
-        return True 
+        """
+        Force the timepoints to use for inference.
+
+        By default, the timepoints are extracted from `exp_data`.
+
+        Parameters
+        ----------
+        timepoints : list or numpy.ndarray
+            The timepoints to use.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.timepoints = timepoints
+        return True
 
     def set_params_to_estimate(self, params_to_estimate: list):
-        '''
-        Set the list of parameters to estimate
-        '''
-        self.params_to_estimate = params_to_estimate 
-        return True 
+        """
+        Set the list of parameters to estimate.
+
+        Parameters
+        ----------
+        params_to_estimate : list of str
+            The names of the parameters in `Model` to estimate.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.params_to_estimate = params_to_estimate
+        return True
 
     def set_sim_type(self, sim_type: str):
-        '''
-        Set the sim_type of simulations to run (deterministic or stochastic) when doing parameter inference
-        '''
-        self.sim_type = sim_type 
-        return True 
+        """
+        Set the type of simulation to use for inference.
+
+        Parameters
+        ----------
+        sim_type : {'deterministic', 'stochastic'}
+            The type of simulation to use for the inference run.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.sim_type = sim_type
+        return True
 
     def set_method(self, method: str):
-        '''
-        Set the parameter identification method to use. 
-        Supported method keywords:
-        * 'emcee' : Uses Python emcee: https://emcee.readthedocs.io/en/stable/
-        * 'lmfit' : Uses Python non-linear least squares package: https://lmfit.github.io/lmfit-py/
-        '''
-        self.method = method 
-        return True 
-        
+        """
+        Set the parameter identification method to use.
+
+        Parameters
+        ----------
+        method : {'emcee', 'lmfit'}
+            The inference package to use: 'emcee' for Bayesian (MCMC)
+            inference (see `emcee <https://emcee.readthedocs.io/en/stable/>`_),
+            or 'lmfit' for non-linear least-squares (see
+            `lmfit <https://lmfit.github.io/lmfit-py/>`_).
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.method = method
+        return True
+
     def set_N_simulations(self, N_simulations: int):
-        '''
-        Set the number of simulations to run for each condition when doing stochastic inference.
-        '''
+        """
+        Set the number of stochastic simulations averaged per data point.
+
+        Only applies when `sim_type` is 'stochastic'.
+
+        Parameters
+        ----------
+        N_simulations : int
+            The number of simulations to run for each condition.
+
+        Returns
+        -------
+        bool or None
+            True if set; otherwise None, with a warning, if `sim_type`
+            is not 'stochastic'.
+        """
         if self.sim_type == 'stochastic':
-            self.N_simulations = N_simulations 
-            return True 
+            self.N_simulations = N_simulations
+            return True
         else:
             warnings.warn('N_simulations needs to be set only for stochastic inference which is not currently the case.')
 
     def set_initial_conditions(self, initial_conditions):
-        '''
-        Set the initial conditions for parameter inference. 
-        Must be a dictionary object with keys pointing 
-        to the species measurements (in order of self.measurements).
-        The dictionary value is the initial condition. 
-        A list of such dictionary may be passed
-        in corresponding to each measurement. 
-        '''
+        """
+        Set the initial condition(s) for the simulated trajectories.
+
+        Parameters
+        ----------
+        initial_conditions : dict or list of dict
+            A dictionary mapping species names to initial values, or a
+            list of such dictionaries (one per trajectory in
+            `exp_data`, in the same order). If None, defaults to
+            `Model`'s own initial conditions.
+
+        Returns
+        -------
+        bool
+            True.
+
+        Raises
+        ------
+        ValueError
+            If `initial_conditions` is a non-empty list containing a
+            non-dict entry.
+        """
         # Get initial_conditions from the model if not given explicitly
-        if initial_conditions is None: 
+        if initial_conditions is None:
             initial_conditions = self.M.get_species_dictionary()
         if type(initial_conditions) is list and len(initial_conditions):
             for curr_ic_index in range(len(initial_conditions)):
@@ -213,39 +469,81 @@ class InferenceSetup(object):
                 if type(ic) is not dict:
                     raise ValueError('All entries in the initial condition list must be dictionaries.')
         self.initial_conditions = initial_conditions
-        return True 
+        return True
 
     def set_parameter_conditions(self, parameter_conditions):
-        '''
-        Set the parameter conditions for parameter inference. 
-        Must be a dictionary object with keys pointing to the 
-        parameters that change with each measurement
-        Value of dictionary is the parameter value. 
-        A list of such dictionaries may be passed in 
-        corresponding to each measurement.
-        '''
+        """
+        Set per-trajectory parameter overrides.
+
+        Parameters
+        ----------
+        parameter_conditions : dict or list of dict
+            A dictionary mapping parameter names (that change between
+            measurements) to values, or a list of such dictionaries
+            (one per trajectory in `exp_data`, in the same order).
+
+        Returns
+        -------
+        bool
+            True.
+        """
         self.parameter_conditions = parameter_conditions
-        return True 
+        return True
 
 
     def set_measurements(self, measurements: list):
-        '''
-        Set the list of measurements (outputs) to look for in exp_data
-        '''
+        """
+        Set the list of measured species to look for in `exp_data`.
+
+        Parameters
+        ----------
+        measurements : list of str
+            The name(s) of the species in `Model` that are measured.
+
+        Returns
+        -------
+        bool
+            True.
+        """
         self.measurements = measurements
-        return True 
+        return True
 
     def set_time_column(self, time_column: str):
-        '''
-        Set the time_column attribute to specify the name of the time column in exp_data
-        '''
-        self.time_column = time_column 
-        return True 
+        """
+        Set the name of the time column in `exp_data`.
+
+        Parameters
+        ----------
+        time_column : str
+            The column name in `exp_data` that holds the time points.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.time_column = time_column
+        return True
 
     def set_exp_data(self, exp_data):
-        '''
-        Set the experimental data to the inference object. Must be a list of Pandas data frame objects.
-        '''
+        """
+        Set the experimental data to fit against.
+
+        Parameters
+        ----------
+        exp_data : pandas.DataFrame or list of pandas.DataFrame
+            The experimental data.
+
+        Returns
+        -------
+        bool
+            True.
+
+        Raises
+        ------
+        ValueError
+            If `exp_data` is not a `pandas.DataFrame` or a list.
+        """
         if isinstance(exp_data, (pd.DataFrame, list)):
             self.exp_data = exp_data
         else:
@@ -253,31 +551,136 @@ class InferenceSetup(object):
         return True
 
     def set_norm_order(self, norm_order: int):
-        '''
-        Set the norm_order used to compute log likelihood
-        '''
-        self.norm_order = norm_order 
-        return True 
+        """
+        Set the norm order used to compute the log-likelihood.
+
+        Parameters
+        ----------
+        norm_order : int
+            The norm used to compute the log-likelihood distance
+            between simulated and measured trajectories.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.norm_order = norm_order
+        return True
 
     def set_parallel(self, parallel: bool):
-        '''
-        Set the parallel flag to use parallel processing for MCMC
-        '''
-        self.parallel = parallel 
+        """
+        Set whether to use parallel processing for MCMC sampling.
+
+        Parameters
+        ----------
+        parallel : bool
+            If True, run MCMC sampling with a `multiprocessing.Pool`.
+
+        Returns
+        -------
+        bool
+            True.
+        """
+        self.parallel = parallel
         return True
-    
+
     def get_parameters(self):
-        '''
-        Returns the list of parameters to estimate that are set for the inference object
-        '''
+        """
+        The list of parameters to estimate.
+
+        Returns
+        -------
+        list of str
+            The names of the parameters in `Model` to estimate.
+        """
         return self.params_to_estimate
 
     def run_mcmc(self, **kwargs):
+        """
+        Run Bayesian (MCMC) parameter inference via `emcee`.
+
+        Prepares the inference (extracting data, setting up the
+        likelihood) and then runs `emcee.EnsembleSampler` for
+        `nsteps` steps with `nwalkers` walkers.
+
+        Parameters
+        ----------
+        timepoints : list or numpy.ndarray, optional
+            Force the timepoints used for inference; see
+            `set_timepoints`.
+        norm_order : int, optional
+            The norm used to compute the log-likelihood; see
+            `set_norm_order`.
+        N_simulations : int, optional
+            The number of stochastic simulations to average per data
+            point; see `set_N_simulations`.
+        init_seed : float or numpy.ndarray or list or 'prior', optional
+            The initial parameter values for the sampler; see
+            `set_init_seed`.
+        debug : bool, optional
+            If True, print verbose diagnostic messages.
+        reuse_likelihood : bool, default False
+            If True, reuse the likelihood set up by a previous call
+            instead of rebuilding it.
+        progress : bool, default True
+            Passed to `emcee.EnsembleSampler.run_mcmc` to show (or
+            hide) a progress bar.
+        skip_initial_state_check : bool, default False
+            Passed to `emcee.EnsembleSampler.run_mcmc`.
+        convergence_check : bool, default False
+            If True, compute the autocorrelation time for each
+            parameter after sampling (stored as
+            `autocorrelation_time`).
+        convergence_diagnostics : bool, default `convergence_check`
+            If True, also store a summary of the autocorrelation time
+            and acceptance fraction (as `convergence_diagnostics`).
+        filename_csv : str, default 'mcmc_results.csv'
+            Where to write the flattened MCMC chain, in the current
+            directory unless a path is given.
+        filename_txt : str, default 'mcmc_results.txt'
+            Where to write a text summary of the cost function
+            progress (and convergence diagnostics, if computed).
+        printout : bool, default True
+            If True, print status messages while running.
+
+        Returns
+        -------
+        emcee.EnsembleSampler
+            The sampler, after running `nsteps` steps.
+        """
         self.prepare_inference(**kwargs)
         sampler = self.run_emcee(**kwargs)
         return sampler
-    
+
     def prepare_inference(self, **kwargs):
+        """
+        Prepare to run inference: extract data and set up conditions.
+
+        Applies any of the `timepoints`/`norm_order`/`N_simulations`/
+        `debug` keyword arguments given, then prepares the initial and
+        parameter conditions and extracts `exp_data` into `LL_data`.
+
+        Parameters
+        ----------
+        timepoints : list or numpy.ndarray, optional
+            Force the timepoints used for inference; see
+            `set_timepoints`.
+        norm_order : int, optional
+            The norm used to compute the log-likelihood; see
+            `set_norm_order`.
+        N_simulations : int, optional
+            The number of stochastic simulations to average per data
+            point; see `set_N_simulations`.
+        debug : bool, optional
+            If True, print verbose diagnostic messages.
+
+        Raises
+        ------
+        ValueError
+            If `timepoints` is given and is not a list or
+            `numpy.ndarray`.
+        """
         timepoints = kwargs.get('timepoints')
         norm_order = kwargs.get('norm_order')
         N_simulations = kwargs.get('N_simulations')
@@ -298,8 +701,17 @@ class InferenceSetup(object):
         self.prepare_parameter_conditions()
         self.LL_data = self.extract_data()
         return
-        
+
     def prepare_initial_conditions(self):
+        """
+        Expand `initial_conditions` to one dict per trajectory in `exp_data`.
+
+        Raises
+        ------
+        ValueError
+            If `initial_conditions` is a list whose length does not
+            match the number of trajectories in `exp_data`.
+        """
         # Create initial conditions as required
         N = 1 if type(self.exp_data) is dict else len(self.exp_data)
         if type(self.initial_conditions) is dict:
@@ -315,6 +727,18 @@ class InferenceSetup(object):
         return
 
     def prepare_parameter_conditions(self):
+        """
+        Expand `parameter_conditions` to one dict per trajectory in `exp_data`.
+
+        Raises
+        ------
+        ValueError
+            If `parameter_conditions` is a list whose length does not
+            match the number of trajectories in `exp_data`.
+        AssertionError
+            If a parameter in `params_to_estimate` also appears in a
+            per-trajectory parameter condition.
+        """
         # Create parameter conditions as required
         N = 1 if type(self.exp_data) is dict else len(self.exp_data)
         if type(self.parameter_conditions) is dict:
@@ -338,6 +762,28 @@ class InferenceSetup(object):
         return
 
     def extract_data(self):
+        """
+        Reshape `exp_data` into a single `(N, T, M)` array.
+
+        Extracts the timepoints (from `time_column`) and measured
+        species (from `measurements`) from `exp_data`, which may be a
+        single `pandas.DataFrame` or a list of them (one per
+        trajectory), into one array of measurements indexed by
+        trajectory, timepoint, and measured species.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape `(N, T, M)`: `N` trajectories, `T`
+            timepoints, `M` measured species.
+
+        Raises
+        ------
+        TypeError
+            If `time_column` is not set, if `exp_data` (or one of its
+            entries, when a list) is not a `pandas.DataFrame`, or if
+            `exp_data` is of an unrecognized type.
+        """
         exp_data = self.exp_data
         # Get timepoints from given experimental data
         if isinstance(self.timepoints, (list, np.ndarray)) and self.debug:
@@ -346,7 +792,7 @@ class InferenceSetup(object):
         if type(exp_data) is list:
             if len(exp_data) == 1:
                 exp_data = exp_data[0]
-        # Multiple trajectories case 
+        # Multiple trajectories case
         if type(exp_data) is list:
             N = len(exp_data)# Number of trajectories
             data_list_final = []
@@ -361,7 +807,7 @@ class InferenceSetup(object):
                     timepoints_list.append(timepoint_i)
                 else:
                     raise TypeError('time_column attribute of InferenceSetup object must be a string.')
-                # Extract measurements    
+                # Extract measurements
                 if type(self.measurements) is list and len(self.measurements) == 1:
                     data_list.append(np.array(df.get(self.measurements[0]), dtype='double'))
                 elif type(self.measurements) is list and len(self.measurements) > 1:
@@ -391,7 +837,7 @@ class InferenceSetup(object):
                 self.timepoints = np.array(exp_data.get(self.time_column), dtype='double').flatten()
             else:
                 raise TypeError('time_column attribute of InferenceSetup object must be a string.')
-            
+
             # Extract measurements
             if type(self.measurements) is list and len(self.measurements) == 1:
                 data = np.array(exp_data.get(self.measurements[0]), dtype='double')
@@ -412,21 +858,57 @@ class InferenceSetup(object):
         return data
 
     def setup_cost_function(self, **kwargs):
+        """
+        Build the `PIDInterface`-derived likelihood object for `sim_type`.
+
+        Constructs a `~bioscrape.pid_interfaces.StochasticInference` or
+        `~bioscrape.pid_interfaces.DeterministicInference` (depending
+        on `sim_type`), and sets it up against `LL_data`. Stores the
+        result as `pid_interface`, used by `cost_function`.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to the `PIDInterface` constructor and to
+            `~bioscrape.pid_interfaces.PIDInterface.setup_likelihood_function`.
+        """
         if self.sim_type == 'stochastic':
             self.pid_interface = StochasticInference(self.params_to_estimate, self.M, self.prior, **kwargs)
-            self.pid_interface.setup_likelihood_function(self.LL_data, self.timepoints, self.measurements, 
-                                                         initial_conditions=self.initial_conditions, 
+            self.pid_interface.setup_likelihood_function(self.LL_data, self.timepoints, self.measurements,
+                                                         initial_conditions=self.initial_conditions,
                                                          parameter_conditions=self.parameter_conditions,
                                                          norm_order = self.norm_order,
                                                          N_simulations = self.N_simulations, **kwargs)
         elif self.sim_type == 'deterministic':
             self.pid_interface = DeterministicInference(self.params_to_estimate, self.M, self.prior, **kwargs)
-            self.pid_interface.setup_likelihood_function(self.LL_data, self.timepoints, self.measurements, 
+            self.pid_interface.setup_likelihood_function(self.LL_data, self.timepoints, self.measurements,
                                                          initial_conditions=self.initial_conditions,
                                                          parameter_conditions=self.parameter_conditions,
                                                          norm_order=self.norm_order, **kwargs)
 
     def cost_function(self, params):
+        """
+        The log-likelihood of `params`, for use as an MCMC cost function.
+
+        Evaluates `pid_interface`'s likelihood at `params`, and records
+        both the value and `params` (in `cost_progress`/`cost_params`)
+        for later inspection.
+
+        Parameters
+        ----------
+        params : array_like
+            The parameter values, in the order of `params_to_estimate`.
+
+        Returns
+        -------
+        float
+            The log-likelihood of `params`.
+
+        Raises
+        ------
+        RuntimeError
+            If `setup_cost_function` has not been called yet.
+        """
         if self.pid_interface is None:
             raise RuntimeError("Must call InferenceSetup.setup_cost_function() \
                                before InferenceSetup.cost_function(params) can be used.")
@@ -436,6 +918,31 @@ class InferenceSetup(object):
         return cost_value
 
     def seed_parameter_values(self, **kwargs):
+        """
+        Sample the initial parameter values for each MCMC walker.
+
+        Uses `init_seed` (optionally overridden by the `init_seed`
+        keyword argument) to determine the initial values; see the
+        class docstring for the supported forms. Values whose prior
+        has a 'positive' flag are clipped to be non-negative (or a
+        small positive epsilon, in log space).
+
+        Parameters
+        ----------
+        init_seed : float or numpy.ndarray or list or 'prior', optional
+            Overrides `init_seed`; see `set_init_seed`.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape `(nwalkers, len(params_to_estimate))` giving
+            the initial parameter values for each walker.
+
+        Raises
+        ------
+        ValueError
+            If `init_seed` is not one of the supported forms.
+        """
         if 'init_seed' in kwargs:
             self.set_init_seed(kwargs['init_seed'])
         ndim = len(self.params_to_estimate)
@@ -482,7 +989,7 @@ class InferenceSetup(object):
                              "array (of size parameters or walkers x parameters), "
                              "or the string 'prior' (will sample from uniform "
                              "and guassian priors)")
-        
+
         #Ensure parameters are positive, if their priors are declared to be positive
         #When working in log space, a small non-zero value is used
         if hasattr(self.pid_interface, "log_space_parameters") and self.pid_interface.log_space_parameters:
@@ -501,7 +1008,34 @@ class InferenceSetup(object):
         return p0
 
     def run_emcee(self, **kwargs):
-        if kwargs.get("reuse_likelihood", False) is False: 
+        """
+        Run `emcee.EnsembleSampler` and write out the results.
+
+        Lower-level than `run_mcmc`: assumes `prepare_inference` has
+        already been called (via `run_mcmc`, or `reuse_likelihood=True`
+        to reuse an existing `pid_interface`). See `run_mcmc` for the
+        accepted keyword arguments.
+
+        Parameters
+        ----------
+        **kwargs
+            See `run_mcmc`; also accepts `reuse_likelihood` (bool,
+            default False) to skip rebuilding the likelihood via
+            `setup_cost_function`.
+
+        Returns
+        -------
+        emcee.EnsembleSampler
+            The sampler, after running `nsteps` steps.
+
+        Raises
+        ------
+        ImportError
+            If the `emcee` package is not installed, or if
+            `parallel` is True and the `multiprocessing` package is
+            not available.
+        """
+        if kwargs.get("reuse_likelihood", False) is False:
             self.setup_cost_function(**kwargs)
         progress = kwargs.get('progress')
         convergence_check = kwargs.get('convergence_check', False)
@@ -569,27 +1103,51 @@ class InferenceSetup(object):
         if printout: print('Successfully completed MCMC parameter identification procedure. '
                            'Check the MCMC diagnostics to evaluate convergence.')
         return sampler
-    
+
     def plot_mcmc_results(self, sampler, **kwargs):
-        """Plots MCMC results collected in emcee.EnsembleSampler object as a corner plot.
-        Args:
-            sampler (emcee.EnsembleSampler): Go to emcee.EnsembleSampler documentation for more.
-    
-        Returns:
-            param_report: A dictionary consisting of true values and uncertainties associated with them
-                          for each parameter.
-                truth list: The truth values for each parameter are computed as 
-                            16th, 50th, and 84th percentiles from sampled data. 
-                            The percentiles may be computed at different values by passing
-                            in the `percentiles` keyword to the function with a list of values.
-                            Default `percentiles = [16,50,84]`.
-                uncertainty list: The uncertainties aaround the true values 
-                                  computed from the samples.
-            figure_objects: A list of three figure related objects:
-                            `[fig, axes, corner_fig]` where `fig` and `axes` correspond 
-                            to the MCMC chain plots and `corner_fig` is the corner figure
-                            object returned by the call to `corner.corner`. If corner plot is not 
-                            shown, then only `[fig, axes]` is returned.
+        """
+        Plot MCMC chain and posterior distributions for a sampled run.
+
+        Parameters
+        ----------
+        sampler : emcee.EnsembleSampler
+            A sampler that has already been run (e.g. the return value
+            of `run_mcmc`).
+        figsize : tuple, default (10, 7)
+            Passed to `matplotlib.pyplot.subplots` for the chain plot.
+        sharex : bool, default True
+            Passed to `matplotlib.pyplot.subplots` for the chain plot.
+        labels : list of str, optional
+            Axis labels for each parameter; defaults to
+            `params_to_estimate`.
+        alpha : float, default 0.3
+            Transparency of the individual walker traces in the chain
+            plot.
+        discard : int, default `2 * nwalkers`
+            Number of initial steps to discard as burn-in before
+            computing the posterior summary and corner plot.
+        thin : int, default 1
+            Keep only every `thin`-th post-burn-in step.
+        flat : bool, default True
+            Passed to `sampler.get_chain` when computing the posterior
+            summary.
+        percentiles : list of float, default [16, 50, 84]
+            Percentiles of the post-burn-in samples to report for each
+            parameter (as `param_report`).
+
+        Returns
+        -------
+        param_report : dict
+            Maps each parameter name plus ``'_true'`` to its 50th
+            percentile value, and plus ``'_uncertainties'`` to the
+            differences between consecutive `percentiles` (by default,
+            the distances from the 16th/84th percentiles to the
+            median).
+        figure_objects : list
+            `[fig, axes, corner_fig]`, where `fig`/`axes` are the
+            per-parameter chain plot and `corner_fig` is the
+            `corner.corner` posterior plot -- or just `[fig, axes]` if
+            the `corner` package is not installed.
         """
         print('Parameter posterior distribution convergence plots:')
         figsize = kwargs.get('figsize', (10,7))
@@ -614,11 +1172,11 @@ class InferenceSetup(object):
             axes.set_xlabel("step number")
         figure_objects.append(fig)
         figure_objects.append(axes)
-        # arbitrarily discard 2*nwalkers steps 
+        # arbitrarily discard 2*nwalkers steps
         discard = kwargs.get('discard', 2*self.nwalkers)
         thin = int(kwargs.get('thin', 1))
         flat = kwargs.get('flat', True)
-        
+
         flat_samples = sampler.get_chain(discard=discard, thin=thin, flat=flat)
         param_report = {}
         # Percentiles to compute for numpy.percentile
@@ -638,12 +1196,30 @@ class InferenceSetup(object):
             figure_objects.append(corner_fig)
         except:
             warnings.warn('corner package not found - cannot plot parameter distributions.')
-        return param_report, figure_objects 
+        return param_report, figure_objects
 
 
     def run_lmfit(self, method = 'leastsq', plot_show = True, **kwargs):
         """
-        Run the Python LMFit package for a bioscrape model.
+        Run least-squares parameter inference via `lmfit`.
+
+        Fits each trajectory in `exp_data` independently with
+        `lmfit.minimize`, using `~bioscrape.pid_interfaces.LMFitInference`.
+
+        Parameters
+        ----------
+        method : str, default 'leastsq'
+            Passed to `lmfit.minimize`; see the
+            `lmfit docs <https://lmfit.github.io/lmfit-py/fitting.html>`_.
+        plot_show : bool, default True
+            If True, display the fit for each trajectory.
+        **kwargs
+            Forwarded to `~bioscrape.pid_interfaces.LMFitInference.get_minimizer_results`.
+
+        Returns
+        -------
+        list of lmfit.minimizer.MinimizerResult
+            One result per trajectory in `exp_data`.
         """
         self.prepare_inference(**kwargs)
         N = np.shape(self.LL_data)[0]
@@ -655,25 +1231,25 @@ class InferenceSetup(object):
         minimizer_result = [None]*N
         if N == 1:
             minimizer_result[0] = self.pid_interface.\
-                get_minimizer_results(self.LL_data[0,:,:], 
+                get_minimizer_results(self.LL_data[0,:,:],
                                       self.timepoints, self.measurements,
                                       initial_conditions = self.initial_conditions,
                                       parameter_conditions = self.parameter_conditions,
                                       stochastic = stochastic, debug = self.debug,
                                       method = method, plot_show = plot_show, **kwargs)
-        else:   
+        else:
             if self.parameter_conditions is None:
                 self.parameter_conditions = [None]*N
             for i in range(N):
                 minimizer_result[i] = self.pid_interface.\
-                    get_minimizer_results(self.LL_data[i,:,:], 
+                    get_minimizer_results(self.LL_data[i,:,:],
                                           self.timepoints[i], self.measurements,
                                           initial_conditions = self.initial_conditions[i],
                                           parameter_conditions = self.parameter_conditions[i],
                                           stochastic = stochastic, debug = self.debug,
                                           method = method, plot_show = plot_show, **kwargs)
         print('Successfully completed parameter identification'
-              ' procedure using LMFit. Parameter values and fitness' 
+              ' procedure using LMFit. Parameter values and fitness'
               ' reports written to lmfit_results.csv file. '
               'Check the minimizer_results object returned to '
               'further statistically evaluate the goodness of fit.')
@@ -681,15 +1257,25 @@ class InferenceSetup(object):
 
     def write_lmfit_results(self, minimizer_result, **kwargs):
         """
-        Process minimizer_result list obtained from LMFit package
-        and plot parameter values on a scatter plot using the corner package.
-        Arguments:
-        * minimizer_result: List of MinimizerResult object (from LMFit package)
-        * kwargs: Passed to the corner package. 
-        Output:
-        * A CSV file: "lmfit_results.csv" is written with each row consisting of the optimized parameter
-        value corresponding to each trajectory in the data.
-        * Corner histogram plot showing the parameter values obtained.
+        Write `run_lmfit` results to a CSV file.
+
+        Writes each trajectory's fitted parameter values to
+        ``lmfit_results.csv`` in the current directory (one row per
+        trajectory), optionally followed by each trajectory's full
+        `lmfit` convergence report.
+
+        Parameters
+        ----------
+        minimizer_result : list of lmfit.minimizer.MinimizerResult
+            The result of `run_lmfit`.
+        convergence_diagnostics : bool, default True
+            If True, append each trajectory's `lmfit.fit_report` to
+            ``lmfit_results.csv``.
+
+        Raises
+        ------
+        ImportError
+            If the `lmfit` package is not installed.
         """
         import csv
         try:
@@ -707,7 +1293,7 @@ class InferenceSetup(object):
         with open('lmfit_results.csv','w') as f:
             f.write(str(df))
 
-        convergence_diagnostics = kwargs.get('convergence_diagnostics', True) 
+        convergence_diagnostics = kwargs.get('convergence_diagnostics', True)
         if convergence_diagnostics:
             count = 0
             for result in minimizer_result:

--- a/bioscrape/pid_interfaces.py
+++ b/bioscrape/pid_interfaces.py
@@ -40,13 +40,14 @@ class PIDInterface():
         `['uniform', lower_bound, upper_bound]` or
         `['gaussian', mean, standard_deviation]`. See `check_prior` for the
         full list of built-in prior types and their parameters.
-    **kwargs
-        Additional keyword arguments, including `log_space_parameters` (bool,
-        default False; whether the parameters being estimated are in log
-        space) and `debug` (bool, default False; if True, print additional
-        diagnostic information during inference).
+    log_space_parameters : bool, default False
+        Whether the parameters being estimated are in log space.
+    debug : bool, default False
+        If True, print additional diagnostic information during
+        inference.
     """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
+        """See class docstring."""
         self.params_to_estimate = params_to_estimate
         self.M = M
         self.prior = prior
@@ -159,9 +160,7 @@ class PIDInterface():
         -------
         float
             The log of the Gaussian probability density (with the mean and
-            standard deviation from `self.prior`) at `param_value`, or
-            `numpy.inf` (with a warning) if the computed probability is
-            negative.
+            standard deviation from `self.prior`) at `param_value`.
 
         Raises
         ------
@@ -358,9 +357,7 @@ class PIDInterface():
         Returns
         -------
         float
-            The log of the log-normal probability density at `param_value`,
-            or `numpy.inf` (with a warning) if the computed probability is
-            negative.
+            The log of the log-normal probability density at `param_value`.
 
         Raises
         ------
@@ -403,10 +400,15 @@ class StochasticInference(PIDInterface):
     prior : dict
         A dictionary specifying the prior distribution for each parameter;
         see `PIDInterface`.
-    **kwargs
-        Additional keyword arguments; see `PIDInterface`.
+    log_space_parameters : bool, default False
+        Whether the parameters being estimated are in log space; see
+        `PIDInterface`.
+    debug : bool, default False
+        If True, print additional diagnostic information during
+        inference.
     """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
+        """See class docstring."""
         self.LL_stoch = None
         self.dataStoch = None
         if 'debug' in kwargs:
@@ -491,9 +493,10 @@ class StochasticInference(PIDInterface):
         Parameters
         ----------
         params : array_like
-            Candidate values for the parameters in `params_to_estimate`, in
-            the same order. If `log_space_parameters` is True, these are
-            interpreted as log-space values and exponentiated before use.
+            Candidate values for the parameters in `self.params_to_estimate`,
+            in the same order. If `self.log_space_parameters` is True,
+            these are interpreted as log-space values and exponentiated
+            before use.
 
         Returns
         -------
@@ -553,10 +556,15 @@ class DeterministicInference(PIDInterface):
     prior : dict
         A dictionary specifying the prior distribution for each parameter;
         see `PIDInterface`.
-    **kwargs
-        Additional keyword arguments; see `PIDInterface`.
+    log_space_parameters : bool, default False
+        Whether the parameters being estimated are in log space; see
+        `PIDInterface`.
+    debug : bool, default False
+        If True, print additional diagnostic information during
+        inference.
     """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
+        """See class docstring."""
         self.LL_det = None
         self.dataDet = None
         self.debug = None
@@ -637,9 +645,10 @@ class DeterministicInference(PIDInterface):
         Parameters
         ----------
         params : array_like
-            Candidate values for the parameters in `params_to_estimate`, in
-            the same order. If `log_space_parameters` is True, these are
-            interpreted as log-space values and exponentiated before use.
+            Candidate values for the parameters in `self.params_to_estimate`,
+            in the same order. If `self.log_space_parameters` is True,
+            these are interpreted as log-space values and exponentiated
+            before use.
 
         Returns
         -------
@@ -703,10 +712,15 @@ class LMFitInference(PIDInterface):
         A dictionary specifying the prior distribution for each parameter;
         used to set the lower/upper bounds passed to `lmfit`. See
         `PIDInterface`.
-    **kwargs
-        Additional keyword arguments; see `PIDInterface`.
+    log_space_parameters : bool, default False
+        Whether the parameters being estimated are in log space; see
+        `PIDInterface`.
+    debug : bool, default False
+        If True, print additional diagnostic information during
+        inference.
     """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
+        """See class docstring."""
         self.residual_function = None
         self.dataLMFit = None
         super().__init__(params_to_estimate, M, prior, **kwargs)
@@ -717,10 +731,10 @@ class LMFitInference(PIDInterface):
                               stochastic = False, debug = False,
                               plot_show = True, **kwargs):
         """
-        Fit `params_to_estimate` to `data` via residual minimization.
+        Fit `self.params_to_estimate` to `data` via residual minimization.
 
-        Builds an `lmfit.Parameters` object from `params_to_estimate` and
-        `self.prior` (using each parameter's prior bounds, or a `[0, inf)`
+        Builds an `lmfit.Parameters` object from `self.params_to_estimate`
+        and `self.prior` (using each parameter's prior bounds, or a `[0, inf)`
         bound if its prior has a 'positive' flag), then calls `lmfit.minimize`
         on a residual function that simulates the model at each candidate
         parameter set and compares it against `data`. If a candidate parameter

--- a/bioscrape/pid_interfaces.py
+++ b/bioscrape/pid_interfaces.py
@@ -1,3 +1,11 @@
+"""
+Parameter identification (PID) interfaces for bioscrape models.
+
+Provides `PIDInterface` and built-in subclasses that connect a
+`~bioscrape.types.Model`, a set of parameters to estimate, and a prior
+specification to the appropriate likelihood function, for use with
+`~bioscrape.inference.py_inference`.
+"""
 from bioscrape.inference import DeterministicLikelihood as DLL
 from bioscrape.inference import StochasticTrajectoriesLikelihood as STLL
 from bioscrape.inference import StochasticTrajectories
@@ -8,31 +16,37 @@ import warnings
 import numpy as np
 
 class PIDInterface():
-    '''
-    PID Interface : Parameter identification interface.
-    Super class to create parameter identification (PID) interfaces. Two PID interfaces currently implemented: 
-    Deterministic and Stochastic Bayesian inference using time-series data.
-    To add a new PIDInterface - simply add a new subclass of this parent class with your desired 
-    log-likelihood functions. You can even have your own check_prior function in that class if you do not 
-    prefer to use the built in priors with this package.
-    '''
-    def __init__(self, params_to_estimate, M, prior, **kwargs):
-        '''
-        Parent class for all PID interfaces.
-        Arguments:
-        * `params_to_estimate` : List of parameter names to be estimated 
-        * `M` : The bioscrape Model object to use for inference
-        * `prior` : A dictionary specifying prior distribution. 
-        Two built-in prior functions are `uniform_prior` and `gaussian_prior`.
-        Each prior has its own syntax for accepting the distribution parameters in the dictionary. 
-        New priors may be added. The suggested format for prior dictionaries:
-        prior_dict = {'parameter_name': ['prior_name', prior_distribution_parameters]}
-        For built-in uniform prior, use {'parameter_name':['uniform', lower_bound, upper_bound]}
-        For built-in gaussian prior, use {'parameter_name':['gaussian', mean, standard_deviation, probability threshold]}
+    """
+    Base class for parameter identification (PID) interfaces.
 
-        New PID interfaces can be added by creating child classes of PIDInterface class as shown for 
-        Built-in PID interfaces : `StochasticInference` and `DeterministicInference`
-        '''
+    Connects a `~bioscrape.types.Model`, a set of parameters to estimate, and
+    a prior specification to a likelihood function, for use with
+    `~bioscrape.inference.py_inference`. Two subclasses are built in:
+    `StochasticInference` and `DeterministicInference`. New interfaces can be
+    added by subclassing `PIDInterface` with the desired log-likelihood
+    functions; a subclass may also override `check_prior` to use custom priors
+    instead of the built-in ones below.
+
+    Parameters
+    ----------
+    params_to_estimate : list of str
+        Names of the parameters to be estimated.
+    M : Model
+        The bioscrape model to use for inference.
+    prior : dict
+        A dictionary specifying the prior distribution for each parameter in
+        `params_to_estimate`. Each entry is a list of the form
+        `['prior_name', *distribution_params]`, e.g.
+        `['uniform', lower_bound, upper_bound]` or
+        `['gaussian', mean, standard_deviation]`. See `check_prior` for the
+        full list of built-in prior types and their parameters.
+    **kwargs
+        Additional keyword arguments, including `log_space_parameters` (bool,
+        default False; whether the parameters being estimated are in log
+        space) and `debug` (bool, default False; if True, print additional
+        diagnostic information during inference).
+    """
+    def __init__(self, params_to_estimate, M, prior, **kwargs):
         self.params_to_estimate = params_to_estimate
         self.M = M
         self.prior = prior
@@ -40,12 +54,30 @@ class PIDInterface():
         self.log_space_parameters = kwargs.get('log_space_parameters', False)
         self.debug = kwargs.get('debug', False)
         return
-    
+
     def check_prior(self, params_dict):
-        '''
-        To add new prior functions: simply add a new function similar to ones that exist and then 
-        call it here.
-        '''
+        """
+        Compute the total log-prior probability for a parameter set.
+
+        Dispatches each parameter in `params_dict` to the built-in prior
+        function matching its type in `self.prior` (e.g. `uniform_prior`,
+        `gaussian_prior`) and sums the results. A 'custom' prior type may
+        supply its own callable directly in the prior dictionary (see
+        `PIDInterface`); for anything more involved, override `check_prior` in
+        a subclass.
+
+        Parameters
+        ----------
+        params_dict : dict
+            Dictionary mapping parameter name to a candidate value.
+
+        Returns
+        -------
+        float
+            The total log-prior probability, or `numpy.inf` if any parameter
+            has a 'positive' prior flag and a negative value, or if any
+            individual prior evaluates to an invalid probability.
+        """
         lp = 0.0
         for key,value in params_dict.items():
             if 'positive' in self.prior[key] and value  < 0:
@@ -68,7 +100,7 @@ class PIDInterface():
             elif prior_type == 'custom':
                 # The last element in the prior dictionary must be a callable function
                 # The callable function shoud have the following signature :
-                # Arguments: param_name (str), param_value(float) 
+                # Arguments: param_name (str), param_value(float)
                 # Returns: log prior probability (float or numpy inf)
                 custom_fuction = self.prior[key][-1]
                 lp += custom_fuction(key, value)
@@ -77,11 +109,30 @@ class PIDInterface():
         return lp
 
     def uniform_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns np.Inf if the param_value is outside the prior range and 0.0 if it is inside. 
-        param_name is used to look for the parameter in the prior dictionary.
-        '''
+        """
+        Log-prior probability of `param_value` under a uniform prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's lower and upper
+            bounds in `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            `numpy.log(1 / (upper_bound - lower_bound))` if `param_value` is
+            within the prior's bounds, otherwise `numpy.inf` (used as a
+            rejection sentinel by `check_prior`).
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None).
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -93,10 +144,30 @@ class PIDInterface():
             return np.log( 1/(upper_bound - lower_bound) )
 
     def gaussian_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.Inf if the param_value is invalid. 
-        '''
+        r"""
+        Log-prior probability of `param_value` under a Gaussian prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's mean and standard
+            deviation in `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            The log of the Gaussian probability density
+            $\mathcal{N}(\mu, \sigma^2)$ at `param_value`, or `numpy.inf`
+            (with a warning) if the computed probability is negative.
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None), or if the prior's standard deviation is negative.
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -114,10 +185,30 @@ class PIDInterface():
             return np.log(prob)
 
     def exponential_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.inf if the param_value is invalid. 
-        '''
+        """
+        Log-prior probability of `param_value` under an exponential prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's rate parameter in
+            `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            The log of the exponential probability density at `param_value`,
+            or `numpy.inf` (with a warning) if the computed probability is
+            negative.
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None).
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -129,12 +220,32 @@ class PIDInterface():
             return np.inf
         else:
             return np.log(prob)
-    
+
     def gamma_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.inf if the param_value is invalid. 
-        '''
+        """
+        Log-prior probability of `param_value` under a gamma prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's shape (`alpha`)
+            and rate (`beta`) parameters in `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            The log of the gamma probability density at `param_value`, or
+            `numpy.inf` (with a warning) if the computed probability is
+            negative.
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None).
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -149,10 +260,30 @@ class PIDInterface():
             return np.log(prob)
 
     def beta_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.inf if the param_value is invalid. 
-        '''
+        """
+        Log-prior probability of `param_value` under a beta prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's `alpha` and `beta`
+            shape parameters in `self.prior`.
+        param_value : float
+            The candidate parameter value (expected in `[0, 1]`).
+
+        Returns
+        -------
+        float
+            The log of the beta probability density at `param_value`, or
+            `numpy.inf` (with a warning) if the computed probability is
+            negative.
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None).
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -167,10 +298,30 @@ class PIDInterface():
             return np.log(prob)
 
     def log_uniform_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.inf if the param_value is invalid. 
-        '''
+        """
+        Log-prior probability of `param_value` under a log-uniform prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's lower and upper
+            bounds in `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            The log of the log-uniform probability density if `param_value` is
+            within the prior's (positive) bounds, otherwise `numpy.inf` (used
+            as a rejection sentinel by `check_prior`).
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None), or if the prior's lower or upper bound is negative.
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -191,10 +342,31 @@ class PIDInterface():
             return np.log(prob)
 
     def log_gaussian_prior(self, param_name, param_value):
-        '''
-        Check if given param_value is valid according to the prior distribution.
-        Returns the log prior probability or np.inf if the param_value is invalid. 
-        '''
+        """
+        Log-prior probability of `param_value` under a log-normal prior.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name; used to look up the prior's mean and standard
+            deviation (of the underlying normal distribution) in
+            `self.prior`.
+        param_value : float
+            The candidate parameter value.
+
+        Returns
+        -------
+        float
+            The log of the log-normal probability density at `param_value`,
+            or `numpy.inf` (with a warning) if the computed probability is
+            negative.
+
+        Raises
+        ------
+        ValueError
+            If no prior was specified for this `PIDInterface` (`self.prior`
+            is None), or if the prior's standard deviation is negative.
+        """
         prior_dict = self.prior
         if prior_dict is None:
             raise ValueError('No prior found')
@@ -212,6 +384,26 @@ class PIDInterface():
 
 # Add a new class similar to this to create new interfaces.
 class StochasticInference(PIDInterface):
+    """
+    PID interface for Bayesian inference against stochastic simulations.
+
+    Fits `~bioscrape.types.Model` parameters to single-cell trajectory data
+    using `~bioscrape.inference.StochasticTrajectoriesLikelihood`, comparing
+    simulated and experimental trajectory statistics rather than individual
+    trajectories.
+
+    Parameters
+    ----------
+    params_to_estimate : list of str
+        Names of the parameters to be estimated.
+    M : Model
+        The bioscrape model to use for inference.
+    prior : dict
+        A dictionary specifying the prior distribution for each parameter;
+        see `PIDInterface`.
+    **kwargs
+        Additional keyword arguments; see `PIDInterface`.
+    """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
         self.LL_stoch = None
         self.dataStoch = None
@@ -224,6 +416,42 @@ class StochasticInference(PIDInterface):
                                   initial_conditions, parameter_conditions,
                                   norm_order=2, N_simulations=3,
                                   **kwargs):
+        """
+        Build the likelihood function used by `get_likelihood_function`.
+
+        Must be called once before `get_likelihood_function`. Wraps `data` in
+        a `~bioscrape.inference.StochasticTrajectories` object and builds a
+        `~bioscrape.inference.StochasticTrajectoriesLikelihood` from it,
+        comparing `N_simulations` stochastic simulations per data point
+        against the trajectory statistics in `data`.
+
+        Parameters
+        ----------
+        data : array_like
+            Experimental trajectory data, of shape
+            `(N, len(timepoints), len(measurements))` for `N` trajectories.
+        timepoints : array_like
+            The time points at which `data` was measured.
+        measurements : list of str
+            The names of the measured species/outputs in `data`.
+        initial_conditions : dict or list of dict
+            Initial condition(s) for the simulated trajectories. A single dict
+            if `data` has one trajectory, or a list of `N` dicts for multiple
+            trajectories.
+        parameter_conditions : dict or list of dict or None
+            Per-trajectory parameter overrides, in the same shape as
+            `initial_conditions`, or None to use the model's default
+            parameters for every trajectory.
+        norm_order : int, optional
+            The norm order used to compare simulated and experimental
+            trajectory statistics (default 2).
+        N_simulations : int, optional
+            The number of stochastic simulations to average per likelihood
+            evaluation (default 3).
+        **kwargs
+            Additional keyword arguments passed to
+            `~bioscrape.inference.StochasticTrajectoriesLikelihood`.
+        """
         N = np.shape(data)[0]
         self.dataStoch = StochasticTrajectories(np.array(timepoints), data, measurements, N)
         if self.debug:
@@ -250,6 +478,32 @@ class StochasticInference(PIDInterface):
 
 
     def get_likelihood_function(self, params):
+        """
+        Compute the log posterior probability for a parameter set.
+
+        Combines the log-prior from `check_prior` with the log-likelihood from
+        the `~bioscrape.inference.StochasticTrajectoriesLikelihood` built by
+        `setup_likelihood_function`. Intended to be passed as the
+        log-probability function for an MCMC sampler such as `emcee`.
+
+        Parameters
+        ----------
+        params : array_like
+            Candidate values for the parameters in `params_to_estimate`, in
+            the same order. If `log_space_parameters` is True, these are
+            interpreted as log-space values and exponentiated before use.
+
+        Returns
+        -------
+        float
+            The log posterior probability, or `-numpy.inf` if the prior
+            rejects `params`.
+
+        Raises
+        ------
+        RuntimeError
+            If called before `setup_likelihood_function`.
+        """
         # Set params here and return the likelihood object.
         if self.LL_stoch is None:
             raise RuntimeError("Must call StochasticInference.setup_likelihood_function before using StochasticInference.get_likelihood_function.")
@@ -278,9 +532,27 @@ class StochasticInference(PIDInterface):
             if self.debug:
                 print('current cost total:', ln_prob)
             return ln_prob
-       
+
 # Add a new class similar to this to create new interfaces.
 class DeterministicInference(PIDInterface):
+    """
+    PID interface for Bayesian inference against deterministic simulations.
+
+    Fits `~bioscrape.types.Model` parameters to bulk (deterministic)
+    trajectory data using `~bioscrape.inference.DeterministicLikelihood`.
+
+    Parameters
+    ----------
+    params_to_estimate : list of str
+        Names of the parameters to be estimated.
+    M : Model
+        The bioscrape model to use for inference.
+    prior : dict
+        A dictionary specifying the prior distribution for each parameter;
+        see `PIDInterface`.
+    **kwargs
+        Additional keyword arguments; see `PIDInterface`.
+    """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
         self.LL_det = None
         self.dataDet = None
@@ -291,13 +563,44 @@ class DeterministicInference(PIDInterface):
         return
 
     def setup_likelihood_function(self, data, timepoints, measurements,
-                                  initial_conditions, parameter_conditions, 
+                                  initial_conditions, parameter_conditions,
                                   norm_order = 2, **kwargs):
+        """
+        Build the likelihood function used by `get_likelihood_function`.
+
+        Must be called once before `get_likelihood_function`. Wraps `data` in
+        a `~bioscrape.inference.BulkData` object and builds a
+        `~bioscrape.inference.DeterministicLikelihood` from it.
+
+        Parameters
+        ----------
+        data : array_like
+            Experimental trajectory data, of shape
+            `(N, len(timepoints), len(measurements))` for `N` trajectories.
+        timepoints : array_like
+            The time points at which `data` was measured.
+        measurements : list of str
+            The names of the measured species/outputs in `data`.
+        initial_conditions : dict or list of dict
+            Initial condition(s) for the simulated trajectories. A single dict
+            if `data` has one trajectory, or a list of `N` dicts for multiple
+            trajectories.
+        parameter_conditions : dict or list of dict or None
+            Per-trajectory parameter overrides, in the same shape as
+            `initial_conditions`, or None to use the model's default
+            parameters for every trajectory.
+        norm_order : int, optional
+            The norm order used to compare simulated and experimental
+            trajectories (default 2).
+        **kwargs
+            Additional keyword arguments passed to
+            `~bioscrape.inference.DeterministicLikelihood`.
+        """
         N = np.shape(data)[0]
         #Create a data Objects
         # In this case the timepoints should be a list of timepoints vectors for each iteration
         self.dataDet = BulkData(np.array(timepoints), data, measurements, N)
-        #If there are multiple initial conditions in a data-set, 
+        #If there are multiple initial conditions in a data-set,
         # should correspond to multiple initial conditions for inference.
         #Note len(initial_conditions) must be equal to the number of trajectories N
         # Similarly, if parameter_conditions are provided then the length must equal
@@ -312,14 +615,40 @@ class DeterministicInference(PIDInterface):
             print('Using the parameter conditions: {0}'.format(parameter_conditions))
         #Create Likelihood object
         if parameter_conditions is not None:
-            self.LL_det = DLL(model = self.M, init_state = initial_conditions, 
-                              init_params = parameter_conditions, 
+            self.LL_det = DLL(model = self.M, init_state = initial_conditions,
+                              init_params = parameter_conditions,
                               data = self.dataDet, norm_order = norm_order, **kwargs)
         else:
-            self.LL_det = DLL(model = self.M, init_state = initial_conditions, 
+            self.LL_det = DLL(model = self.M, init_state = initial_conditions,
                               data = self.dataDet, norm_order = norm_order, **kwargs)
 
     def get_likelihood_function(self, params):
+        """
+        Compute the log posterior probability for a parameter set.
+
+        Combines the log-prior from `check_prior` with the log-likelihood from
+        the `~bioscrape.inference.DeterministicLikelihood` built by
+        `setup_likelihood_function`. Intended to be passed as the
+        log-probability function for an MCMC sampler such as `emcee`.
+
+        Parameters
+        ----------
+        params : array_like
+            Candidate values for the parameters in `params_to_estimate`, in
+            the same order. If `log_space_parameters` is True, these are
+            interpreted as log-space values and exponentiated before use.
+
+        Returns
+        -------
+        float
+            The log posterior probability, or `-numpy.inf` if the prior
+            rejects `params`.
+
+        Raises
+        ------
+        RuntimeError
+            If called before `setup_likelihood_function`.
+        """
         if self.LL_det is None:
             raise RuntimeError("Must call DeterministicInference.setup_likelihood_function before using DeterministicInference.get_likelihood_function.")
         #this part is the only part that is called repeatedly
@@ -329,7 +658,7 @@ class DeterministicInference(PIDInterface):
                 params_dict[key] = np.exp(p)
             else:
                 params_dict[key] = p
-        
+
         # Check prior
         lp = 0
         lp = self.check_prior(params_dict)
@@ -351,9 +680,29 @@ class DeterministicInference(PIDInterface):
                 print('current cost total:', ln_prob)
             #print("params", params, "ln_prob", ln_prob)
             return ln_prob
-        
+
 class LMFitInference(PIDInterface):
-    
+    """
+    PID interface for least-squares/maximum-likelihood parameter fitting.
+
+    Provides a point-estimate alternative to the MCMC-based
+    `StochasticInference`/`DeterministicInference`, built on
+    `lmfit <https://lmfit.github.io/lmfit-py/>`_, for cases where a full
+    posterior is not needed.
+
+    Parameters
+    ----------
+    params_to_estimate : list of str
+        Names of the parameters to be estimated.
+    M : Model
+        The bioscrape model to use for inference.
+    prior : dict
+        A dictionary specifying the prior distribution for each parameter;
+        used to set the lower/upper bounds passed to `lmfit`. See
+        `PIDInterface`.
+    **kwargs
+        Additional keyword arguments; see `PIDInterface`.
+    """
     def __init__(self, params_to_estimate, M, prior, **kwargs):
         self.residual_function = None
         self.dataLMFit = None
@@ -364,8 +713,54 @@ class LMFitInference(PIDInterface):
                               parameter_conditions, method = 'leastsq',
                               stochastic = False, debug = False,
                               plot_show = True, **kwargs):
+        """
+        Fit `params_to_estimate` to `data` via residual minimization.
+
+        Builds an `lmfit.Parameters` object from `params_to_estimate` and
+        `self.prior` (using each parameter's prior bounds, or a `[0, inf)`
+        bound if its prior has a 'positive' flag), then calls `lmfit.minimize`
+        on a residual function that simulates the model at each candidate
+        parameter set and compares it against `data`. If a candidate parameter
+        set is rejected by `check_prior`, the residual is set to NaN for that
+        evaluation (handled via `nan_policy='propagate'`).
+
+        Parameters
+        ----------
+        data : array_like
+            Experimental trajectory data, of shape
+            `(len(timepoints), len(measurements))`.
+        timepoints : array_like
+            The time points at which `data` was measured.
+        measurements : list of str
+            The names of the measured species/outputs in `data`.
+        initial_conditions : dict
+            Initial conditions for the simulated trajectory.
+        parameter_conditions : dict or None
+            Parameter overrides to apply before simulating, or None to use the
+            model's default parameters.
+        method : str, optional
+            The `lmfit` minimization method to use (default 'leastsq'); see
+            the `lmfit docs <https://lmfit.github.io/lmfit-py/fitting.html>`_
+            for the full list.
+        stochastic : bool, optional
+            If True, simulate stochastically instead of deterministically
+            (default False).
+        debug : bool, optional
+            If True, print additional diagnostic information (default False).
+        plot_show : bool, optional
+            If True, plot the fitted simulation against `data` for each
+            measured species using matplotlib (default True).
+        **kwargs
+            Additional keyword arguments passed to `lmfit.minimize`.
+
+        Returns
+        -------
+        lmfit.minimizer.MinimizerResult
+            The result object returned by `lmfit.minimize`, including the
+            fitted parameter values.
+        """
         # In this case the timepoints should be a list of timepoints vectors for each iteration
-        #If there are multiple initial conditions in a data-set, 
+        #If there are multiple initial conditions in a data-set,
         # should correspond to multiple initial conditions for inference.
         #Note len(initial_conditions) must be equal to the number of trajectories N
         # Same holds for parameter_conditions
@@ -402,7 +797,7 @@ class LMFitInference(PIDInterface):
             measurements_counter = 0
             for species in measurements:
                 residual_value += lp + np.reshape(np.array(model_sim[species]), (len(timepoints))) - data[:,measurements_counter]
-                measurements_counter += 1 
+                measurements_counter += 1
             return residual_value
         model_param_dict = self.M.get_parameter_dictionary()
         # Create LMFit parameter objects
@@ -435,7 +830,7 @@ class LMFitInference(PIDInterface):
             for species in measurements:
                 plt.plot(timepoints, model_sim_fit[species], color = 'orange', alpha = 0.5)
                 plt.plot(timepoints, data[:,measurements_counter], color = 'black', ls = 'dotted')
-                measurements_counter += 1 
+                measurements_counter += 1
             plt.xlabel('Time', fontsize = 14)
             plt.ylabel('Species', fontsize = 14)
         return result

--- a/bioscrape/pid_interfaces.py
+++ b/bioscrape/pid_interfaces.py
@@ -144,7 +144,7 @@ class PIDInterface():
             return np.log( 1/(upper_bound - lower_bound) )
 
     def gaussian_prior(self, param_name, param_value):
-        r"""
+        """
         Log-prior probability of `param_value` under a Gaussian prior.
 
         Parameters
@@ -158,9 +158,10 @@ class PIDInterface():
         Returns
         -------
         float
-            The log of the Gaussian probability density
-            $\mathcal{N}(\mu, \sigma^2)$ at `param_value`, or `numpy.inf`
-            (with a warning) if the computed probability is negative.
+            The log of the Gaussian probability density (with the mean and
+            standard deviation from `self.prior`) at `param_value`, or
+            `numpy.inf` (with a warning) if the computed probability is
+            negative.
 
         Raises
         ------

--- a/bioscrape/pid_interfaces.py
+++ b/bioscrape/pid_interfaces.py
@@ -385,11 +385,12 @@ class PIDInterface():
 # Add a new class similar to this to create new interfaces.
 class StochasticInference(PIDInterface):
     """
-    PID interface for Bayesian inference against stochastic simulations.
+    PID interface for Bayesian inference of stochastic models.
 
     Fits `~bioscrape.types.Model` parameters to single-cell trajectory data
-    using `~bioscrape.inference.StochasticTrajectoriesLikelihood`, comparing
-    simulated and experimental trajectory statistics rather than individual
+    (which may come from experiments or from another simulation) using
+    `~bioscrape.inference.StochasticTrajectoriesLikelihood`, comparing
+    simulated and measured trajectory statistics rather than individual
     trajectories.
 
     Parameters
@@ -536,10 +537,11 @@ class StochasticInference(PIDInterface):
 # Add a new class similar to this to create new interfaces.
 class DeterministicInference(PIDInterface):
     """
-    PID interface for Bayesian inference against deterministic simulations.
+    PID interface for Bayesian inference of deterministic models.
 
-    Fits `~bioscrape.types.Model` parameters to bulk (deterministic)
-    trajectory data using `~bioscrape.inference.DeterministicLikelihood`.
+    Fits `~bioscrape.types.Model` parameters to bulk time-series data
+    (which may come from experiments or from another simulation) using
+    `~bioscrape.inference.DeterministicLikelihood`.
 
     Parameters
     ----------

--- a/bioscrape/sbmlutil.py
+++ b/bioscrape/sbmlutil.py
@@ -1,3 +1,10 @@
+"""
+SBML import/export helpers used internally by `bioscrape.types.Model`.
+
+Most users interact with these indirectly through
+`Model(sbml_filename=...)` and `~bioscrape.types.Model.write_sbml_model`
+rather than calling them directly.
+"""
 import numpy as np
 import sympy
 from sympy.abc import _clash1
@@ -7,18 +14,70 @@ import libsbml
 from collections import OrderedDict # Need this to remove duplicates from lists
 
 def read_model_from_sbml(sbml_file):
+    """Read an SBML file into a new bioscrape `Model`.
+
+    Convenience wrapper around `import_sbml` that always creates a
+    new `Model` rather than modifying an existing one.
+
+    Parameters
+    ----------
+    sbml_file : str
+        Path to the SBML file to read.
+
+    Returns
+    -------
+    Model
+        The imported model.
+    """
     return import_sbml(sbml_file)
 
 def import_sbml(sbml_file, bioscrape_model = None, input_printout = False, **kwargs):
-    """
-    Convert SBML model (in the sbml_file) to bioscrape Model object. Note that events, compartments, non-standard function definitions,
-    and some kinds of rules will be ignored.
-    Adds mass action kinetics based reactions with the appropriate mass action propensity in bioscrape.
-    Propensities with the correct annotation are added as compiled propensity types.
-    All other propensities are added as general propensity.
-    Bioscrape delays are imported if SBML reaction has appropriate annotation.
-    All SBML rules (except Algebraic) are imported. Bioscrape rule settings are imported as annotation.
-    Local parameters are renamed if there is a conflict since bioscrape does not have a local environment.
+    """Import an SBML model into a bioscrape `Model`.
+
+    Events, compartments, non-standard function definitions, and some kinds of
+    rules are not recognized by bioscrape and are ignored
+    (compartments/units/events and Algebraic rules trigger a warning; function
+    definitions are dropped silently). Mass-action reactions are added with
+    the appropriate mass-action propensity; propensities with the correct
+    bioscrape annotation are added as their compiled propensity type, and all
+    other propensities as a general propensity. Delays are imported if a
+    reaction has the appropriate annotation. All SBML rules except Algebraic
+    rules are imported, with bioscrape-specific rule settings imported from
+    annotations. Local (reaction-scoped) parameters are renamed on conflict,
+    since bioscrape has no local parameter scope.
+
+    Parameters
+    ----------
+    sbml_file : str
+        Path to the SBML file to read.
+    bioscrape_model : Model, optional
+        If given, species/parameters/reactions/rules are added to
+        this model instead of a newly created one.
+    input_printout : bool, default False
+        If True, print each species/parameter as it's added.
+    sbml_warnings : bool, optional
+        If True, warn about unrecognized SBML components
+        (compartments, unit definitions, events). Defaults to False
+        if the SBML model's ID contains ``'bioscrape'`` or
+        ``'biocrnpyler'``, True otherwise.
+    **kwargs
+        Additional keyword arguments (currently only
+        `sbml_warnings` is recognized).
+
+    Returns
+    -------
+    Model
+        The imported model (`bioscrape_model`, if given).
+
+    Raises
+    ------
+    ImportError
+        If the `libsbml` package is not installed.
+    SyntaxError
+        If the SBML file has read errors.
+    ValueError
+        If the SBML file can't be found, or if `bioscrape_model` is
+        given and is not a `Model`.
     """
     # Attempt to import libsbml and read the SBML model.
     try:
@@ -405,8 +464,38 @@ def _get_species_list_in_formula(formula, species):
 
 def create_sbml_model(compartment_id="default", time_units='second', extent_units='mole', substance_units='mole',
                       length_units='metre', area_units='square_metre', volume_units='litre', volume = 1e-6):
+    """Create an empty SBML document and model with one compartment.
+
+    Parameters
+    ----------
+    compartment_id : str, default "default"
+        ID (and name) of the single default compartment.
+    time_units : str, default "second"
+        Model-wide time units.
+    extent_units : str, default "mole"
+        Model-wide units of reaction extent.
+    substance_units : str, default "mole"
+        Model-wide substance units.
+    length_units : str, default "metre"
+        Model-wide length units.
+    area_units : str, default "square_metre"
+        Model-wide area units.
+    volume_units : str, default "litre"
+        Model-wide volume units.
+    volume : float, default 1e-6
+        The default compartment's volume.
+
+    Returns
+    -------
+    document : libsbml.SBMLDocument
+        The created SBML document.
+    model : libsbml.Model
+        The created SBML model (also reachable via
+        ``document.getModel()``, with the compartment via
+        ``model.getCompartment(0)``).
+    """
     # Create an empty SBML Document of Level 3 Version 2 of SBML
-    document = libsbml.SBMLDocument(3, 2) 
+    document = libsbml.SBMLDocument(3, 2)
     model = document.createModel()
     model.setId('bioscrape_generated_model_' + str(np.random.randint(1e6)))
     # Define units for area (not used, but keeps COPASI from complaining)
@@ -454,6 +543,33 @@ def species_sbml_id(species_name, document=None):
 # Helper function to add a species to the model
 # species must be chemical_reaction_network.species objects
 def add_species(model, compartment, species, debug=False, initial_concentration=None):
+    """Add a species to an SBML model.
+
+    Parameters
+    ----------
+    model : libsbml.Model
+        The SBML model to add the species to.
+    compartment : libsbml.Compartment
+        The compartment the species belongs to.
+    species : str
+        The species name. Must be a valid SBML identifier (no
+        colons, semicolons, or other special characters; can't start
+        with a number; must be unique).
+    debug : bool, default False
+        If True, print the species name and ID as it's added.
+    initial_concentration : float, optional
+        The species' initial concentration. Defaults to 0.
+
+    Returns
+    -------
+    libsbml.Species
+        The created SBML species.
+
+    Raises
+    ------
+    ValueError
+        If `species` is not a valid SBML identifier.
+    """
     model = model  # Get the model where we will store results
 
     # Construct the species name
@@ -484,6 +600,29 @@ def add_species(model, compartment, species, debug=False, initial_concentration=
 
 # Helper function to add a parameter to the model
 def add_parameter(model, param_name, param_value, debug=False):
+    """Add a parameter to an SBML model.
+
+    A single leading underscore in `param_name` is stripped (used
+    elsewhere to disambiguate parameter names from species names).
+    The parameter is created with ``constant=True``; this is set to
+    False later if a rule assigns to it.
+
+    Parameters
+    ----------
+    model : libsbml.Model
+        The SBML model to add the parameter to.
+    param_name : str
+        The parameter name.
+    param_value : float
+        The parameter's value.
+    debug : bool, default False
+        If True, print the parameter name as it's added.
+
+    Returns
+    -------
+    libsbml.Parameter
+        The created SBML parameter.
+    """
     # Check to see if this parameter is already present
     parameter = model.createParameter()
     # all_ids = getAllIds(model.getSBMLDocument().getListOfAllElements())
@@ -504,6 +643,40 @@ def add_parameter(model, param_name, param_value, debug=False):
 
 # Helper function to add a rule to an sbml model
 def add_rule(model, rule_id, rule_type, rule_variable, rule_formula, rule_frequency, **kwargs):
+    """Add a rule to an SBML model.
+
+    Bioscrape's ``'assignment'``/``'additive'`` rule types map to an
+    SBML assignment rule; ``'ode'``/``'ODE'``/``'GeneralODERule'``
+    maps to an SBML rate rule. The bioscrape `rule_frequency` is
+    stored in a ``<BioscrapeAnnotation>`` since SBML has no
+    equivalent concept.
+
+    Parameters
+    ----------
+    model : libsbml.Model
+        The SBML model to add the rule to.
+    rule_id : str
+        ID (and name) for the created rule.
+    rule_type : str
+        One of ``'assignment'``, ``'additive'``, ``'ode'``,
+        ``'ODE'``, or ``'GeneralODERule'``.
+    rule_variable : str
+        ID of the species or parameter the rule assigns to.
+    rule_formula : str
+        The rule's right-hand-side formula.
+    rule_frequency : str
+        The bioscrape rule frequency, stored as an annotation.
+
+    Returns
+    -------
+    libsbml.Rule
+        The created SBML rule.
+
+    Raises
+    ------
+    ValueError
+        If `rule_type` is not a recognized type.
+    """
     # Create SBML equivalent of bioscrape rule:
     # Set constant attribute for parameter to False if rule is on a parameter.
     for param in model.getListOfParameters():
@@ -535,7 +708,56 @@ def add_rule(model, rule_id, rule_type, rule_variable, rule_formula, rule_freque
 def add_reaction(model, inputs_list, outputs_list,
                  reaction_id, propensity_type, propensity_params,
                  stochastic = False, delay_annotation_dict = None):
+    """Add a reaction to an SBML model.
 
+    Builds the reaction's rate law from `propensity_type` and
+    `propensity_params`, and stores the propensity type (and delay,
+    if given) as a ``<BioscrapeAnnotation>`` so the reaction can be
+    round-tripped back through `import_sbml`.
+
+    Parameters
+    ----------
+    model : libsbml.Model
+        The SBML model to add the reaction to.
+    inputs_list : list of str
+        Reactant species names; a name repeated N times gives it
+        stoichiometry N.
+    outputs_list : list of str
+        Product species names; a name repeated N times gives it
+        stoichiometry N.
+    reaction_id : str
+        Requested ID for the reaction (made unique if it collides
+        with an existing SBML identifier).
+    propensity_type : str
+        One of ``'massaction'``, ``'hillpositive'``,
+        ``'hillnegative'``, ``'proportionalhillpositive'``,
+        ``'proportionalhillnegative'``, or ``'general'``.
+    propensity_params : dict
+        Parameters for the given propensity type: ``'k'`` for
+        ``'massaction'``/Hill types (plus ``'K'``, ``'n'``, and
+        ``'s1'`` for Hill types, and ``'d'`` for the proportional
+        Hill types), or ``'rate'`` for ``'general'``.
+    stochastic : bool, default False
+        If True, write a stochastic mass-action rate law (using
+        falling-factorial terms for self-reacting species). If
+        False, write a deterministic mass-action rate law.
+    delay_annotation_dict : dict, optional
+        If given, a delay description to store alongside the
+        propensity annotation, with keys ``'type'``, ``'reactants'``,
+        ``'products'``, and ``'parameters'``.
+
+    Returns
+    -------
+    libsbml.Reaction
+        The created SBML reaction.
+
+    Raises
+    ------
+    ValueError
+        If `propensity_type` is not recognized, if a Hill-type
+        propensity is missing a required key in `propensity_params`,
+        or if the rate law formula could not be written to SBML.
+    """
     # Create the reaction
     # We cast to an OrderedDict and back to remove duplicates.
     # We could cast to a regular dict instead, but only in Python 3.7 or higher.
@@ -906,7 +1128,20 @@ import time
 # This class implements an identifier transformer, that means it can be used
 # to rename all sbase elements.
 class SetIdFromNames(libsbml.IdentifierTransformer):
+    """Assigns SBML-valid, unique IDs to elements based on their names.
+
+    An `libsbml.IdentifierTransformer` that can be passed to
+    ``document.getModel().renameIDs()`` (see `renameSIds`) or used
+    directly to generate SBML identifiers from arbitrary names (e.g.
+    bioscrape species/parameter names) via `getValidIdForName`.
+
+    Parameters
+    ----------
+    ids : list of str
+        IDs already in use; new IDs are generated to avoid these.
+    """
     def __init__(self, ids):
+        """See class docstring."""
         # call the constructor of the base class
         libsbml.IdentifierTransformer.__init__(self)
         # remember existing ids ...
@@ -916,6 +1151,22 @@ class SetIdFromNames(libsbml.IdentifierTransformer):
 
     # once for each SBase element in the model.
     def transform(self, element):
+        """Set `element`'s ID from its name, if it doesn't have one.
+
+        Called once per SBase element by libsbml's ID-transformation
+        machinery; not normally called directly.
+
+        Parameters
+        ----------
+        element : libsbml.SBase
+            The element to (possibly) assign an ID to.
+
+        Returns
+        -------
+        int
+            An libsbml operation-result code (always
+            ``LIBSBML_OPERATION_SUCCESS``).
+        """
         # return in case we don't have a valid element
         if (element == None \
            or element.getTypeCode() == libsbml.SBML_LOCAL_PARAMETER):
@@ -938,6 +1189,23 @@ class SetIdFromNames(libsbml.IdentifierTransformer):
         return libsbml.LIBSBML_OPERATION_SUCCESS
 
     def nameToSbmlId(self, name):
+        """Convert a name to a valid (but not necessarily unique) SBML ID.
+
+        Non-alphanumeric characters become underscores; a leading
+        digit is prefixed with ``x_``; an ``'xx'`` marker is
+        inserted if `name` contains ``'*'``; a trailing underscore
+        is stripped.
+
+        Parameters
+        ----------
+        name : str
+            The name to convert.
+
+        Returns
+        -------
+        str
+            A valid SBML identifier derived from `name`.
+        """
         IdStream = []
         count = 0
         end = len(name)
@@ -964,6 +1232,21 @@ class SetIdFromNames(libsbml.IdentifierTransformer):
     # It does so by appending numbers to the original name.
     #
     def getValidIdForName(self, name):
+        """Convert a name to a valid, unique SBML ID.
+
+        Like `nameToSbmlId`, but appends ``_1``, ``_2``, etc. as
+        needed to avoid colliding with `existingIds`.
+
+        Parameters
+        ----------
+        name : str
+            The name to convert.
+
+        Returns
+        -------
+        str
+            A valid, unique SBML identifier derived from `name`.
+        """
         baseString = self.nameToSbmlId(name)
         id = baseString
         count = 1

--- a/bioscrape/sbmlutil.py
+++ b/bioscrape/sbmlutil.py
@@ -58,8 +58,8 @@ def import_sbml(sbml_file, bioscrape_model = None, input_printout = False, **kwa
     sbml_warnings : bool, optional
         If True, warn about unrecognized SBML components
         (compartments, unit definitions, events). Defaults to False
-        if the SBML model's ID contains ``'bioscrape'`` or
-        ``'biocrnpyler'``, True otherwise.
+        if the SBML model's ID contains 'bioscrape' or
+        'biocrnpyler', True otherwise.
     **kwargs
         Additional keyword arguments (currently only
         `sbml_warnings` is recognized).
@@ -156,7 +156,7 @@ def import_sbml(sbml_file, bioscrape_model = None, input_printout = False, **kwa
         raise ValueError("bioscrape_model keyword must be a Bioscrape Model object or None (in which case a Model object is returned).")
 
 def import_sbml_species(sbml_model):
-    """Import species from SBML model
+    """Import species from SBML model.
 
     Args:
         sbml_model ([Model]): libsbml Model object
@@ -179,7 +179,7 @@ def import_sbml_species(sbml_model):
     return allspecies
 
 def import_sbml_parameters(sbml_model):
-    """Import parameters from SBML model
+    """Import parameters from SBML model.
 
     Args:
         sbml_model ([Model]): libsbml Model object
@@ -195,7 +195,7 @@ def import_sbml_parameters(sbml_model):
     return allparams
 
 def import_sbml_reactions(sbml_model, allspecies, allparams, input_printout, sbml_warnings = True):
-    """Import reactions from SBML model
+    """Import reactions from SBML model.
 
     Args:
         sbml_model ([Model]): libsbml Model object
@@ -645,8 +645,8 @@ def add_parameter(model, param_name, param_value, debug=False):
 def add_rule(model, rule_id, rule_type, rule_variable, rule_formula, rule_frequency, **kwargs):
     """Add a rule to an SBML model.
 
-    Bioscrape's ``'assignment'``/``'additive'`` rule types map to an
-    SBML assignment rule; ``'ode'``/``'ODE'``/``'GeneralODERule'``
+    Bioscrape's 'assignment'/'additive' rule types map to an
+    SBML assignment rule; 'ode'/'ODE'/'GeneralODERule'
     maps to an SBML rate rule. The bioscrape `rule_frequency` is
     stored in a ``<BioscrapeAnnotation>`` since SBML has no
     equivalent concept.
@@ -658,8 +658,8 @@ def add_rule(model, rule_id, rule_type, rule_variable, rule_formula, rule_freque
     rule_id : str
         ID (and name) for the created rule.
     rule_type : str
-        One of ``'assignment'``, ``'additive'``, ``'ode'``,
-        ``'ODE'``, or ``'GeneralODERule'``.
+        One of 'assignment', 'additive', 'ode',
+        'ODE', or 'GeneralODERule'.
     rule_variable : str
         ID of the species or parameter the rule assigns to.
     rule_formula : str
@@ -729,22 +729,22 @@ def add_reaction(model, inputs_list, outputs_list,
         Requested ID for the reaction (made unique if it collides
         with an existing SBML identifier).
     propensity_type : str
-        One of ``'massaction'``, ``'hillpositive'``,
-        ``'hillnegative'``, ``'proportionalhillpositive'``,
-        ``'proportionalhillnegative'``, or ``'general'``.
+        One of 'massaction', 'hillpositive',
+        'hillnegative', 'proportionalhillpositive',
+        'proportionalhillnegative', or 'general'.
     propensity_params : dict
-        Parameters for the given propensity type: ``'k'`` for
-        ``'massaction'``/Hill types (plus ``'K'``, ``'n'``, and
-        ``'s1'`` for Hill types, and ``'d'`` for the proportional
-        Hill types), or ``'rate'`` for ``'general'``.
+        Parameters for the given propensity type: 'k' for
+        'massaction'/Hill types (plus 'K', 'n', and
+        's1' for Hill types, and 'd' for the proportional
+        Hill types), or 'rate' for 'general'.
     stochastic : bool, default False
         If True, write a stochastic mass-action rate law (using
         falling-factorial terms for self-reacting species). If
         False, write a deterministic mass-action rate law.
     delay_annotation_dict : dict, optional
         If given, a delay description to store alongside the
-        propensity annotation, with keys ``'type'``, ``'reactants'``,
-        ``'products'``, and ``'parameters'``.
+        propensity annotation, with keys 'type', 'reactants',
+        'products', and 'parameters'.
 
     Returns
     -------
@@ -994,7 +994,7 @@ def getAllIds(allElements):
 def renameSIds(document, oldSIds, newSIds, debug = False):
     '''
     Updates the SId from oldSId to newSId for any component of the Subsystem.
-    Returns the SBMLDocument of the updated Subsystem
+    Returns the SBMLDocument of the updated Subsystem.
     '''
 
     #
@@ -1192,8 +1192,8 @@ class SetIdFromNames(libsbml.IdentifierTransformer):
         """Convert a name to a valid (but not necessarily unique) SBML ID.
 
         Non-alphanumeric characters become underscores; a leading
-        digit is prefixed with ``x_``; an ``'xx'`` marker is
-        inserted if `name` contains ``'*'``; a trailing underscore
+        digit is prefixed with ``x_``; an 'xx' marker is
+        inserted if `name` contains '*'; a trailing underscore
         is stripped.
 
         Parameters
@@ -1260,9 +1260,10 @@ class SetIdFromNames(libsbml.IdentifierTransformer):
 
 def getSpeciesByName(model, name, compartment=''):
     '''
-    Returns a list of species in the Model with the given name
-    compartment : (Optional) argument to specify the compartment name in which
-    to look for the species.
+    Returns a list of species in the Model with the given name.
+
+    compartment : (Optional) argument to specify the compartment name in
+    which to look for the species.
     '''
     if type(name) is not str:
         raise ValueError('"name" must be a string.')

--- a/bioscrape/simulator.pxd
+++ b/bioscrape/simulator.pxd
@@ -1,3 +1,7 @@
+# NOTE: class/method docstrings live in simulator.pyx, not here. If
+# both files define a docstring for the same class/method, the .pyx
+# one silently wins with no warning at compile time.
+
 cimport numpy as np
 from types cimport  Model, Volume, Schnitz, Lineage
 from vector cimport vector
@@ -7,11 +11,6 @@ from vector cimport vector
 #################################################                     ################################################
 
 cdef class DelayQueue:
-    """
-    An interface/virtual class for keeping track of queued delayed reactions that will resolve at some future time.
-
-    This must be subclassed by implementations of delay queues.
-    """
     cdef void add_reaction(self, double time, unsigned rxn_id, double amount)
     cdef double get_next_queue_time(self)
     cdef void get_next_reactions(self, double *rxn_array)
@@ -23,22 +22,6 @@ cdef class DelayQueue:
     cdef np.ndarray binomial_partition(self, double p)
 
 cdef class ArrayDelayQueue(DelayQueue):
-    """
-    A class implementing the DelayQueue interface with an array of future times book-keeping how many of each rection
-    occurs at each future time with resolution dt.
-
-    Attributes:
-        dt (double): The time resolution
-        next_queue_time (double): The next gridded time point. These are spaced by dt.
-        num_cols (unsigned): The number of cols in the delay queue array. This is the number of dt grid points ahead
-        num_reactions (unsigned): The number of reactions in the system. Also the number of rows in the queue array.
-        start_index (unsigned): The index in the queue array corresponding to the next queue time. This cycles around.
-        queue (np.ndarray): 2-D array where the columns are future time points spaced by dt and the rows are future rxn
-                            occurrences for each reaction. The start index is the very next time and each successive
-                            index corresponds to dt more than the previous one including looping around the end of the
-                            array. Thus, the max future time that can be remembered is dt*num_cols
-
-    """
     cdef double dt
     cdef double next_queue_time
     cdef unsigned num_cols
@@ -61,9 +44,6 @@ cdef class ArrayDelayQueue(DelayQueue):
 
 
 cdef class CSimInterface:
-    """
-    An interface for keeping track of the stoichiometric matrix and delay
-    """
     cdef np.ndarray update_array
     cdef np.ndarray delay_update_array
 
@@ -157,9 +137,6 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
     
 # Simulation output values here
 cdef class SSAResult:
-    """
-    A class for keeping track of the result from a regular simulation (timepoints and species over time).
-    """
     cdef np.ndarray timepoints
     cdef np.ndarray simulation_result
 
@@ -176,19 +153,12 @@ cdef class SSAResult:
         return self.simulation_result
 
 cdef class DelaySSAResult(SSAResult):
-    """
-    A class for keeping track of the result from a delay simulation (timepoints and species and the final set
-    of  queued reactions).
-    """
     cdef DelayQueue final_delay_queue
 
     cdef inline DelayQueue get_delay_queue(self):
         return self.final_delay_queue
 
 cdef class VolumeSSAResult(SSAResult):
-    """
-    A class for keeping track of the result from a volume simulation (timepoints and species/volume over time).
-    """
     cdef np.ndarray volume
     cdef unsigned cell_divided_flag
     cdef unsigned cell_dead_flag
@@ -215,10 +185,6 @@ cdef class VolumeSSAResult(SSAResult):
 
 
 cdef class DelayVolumeSSAResult(VolumeSSAResult):
-    """
-    A class for keeping track of the result from a volume simulation with delay (timepoints and species/volume over
-    time and the final set of queued reactions).
-    """
     cdef DelayQueue final_delay_queue
 
     cdef inline DelayQueue get_delay_queue(self):
@@ -230,9 +196,6 @@ cdef class DelayVolumeSSAResult(VolumeSSAResult):
 # Cell state classes
 
 cdef class CellState:
-    """
-    A class for keeping track of a simple cell state (species and time).
-    """
     cdef np.ndarray state
     cdef double time
 
@@ -249,9 +212,6 @@ cdef class CellState:
         return self.time
 
 cdef class DelayCellState(CellState):
-    """
-    A class for keeping track of cell state in a delay system (species, time, and queued reactions).
-    """
     cdef DelayQueue delay_queue
 
     cdef inline DelayQueue get_delay_queue(self):
@@ -261,9 +221,6 @@ cdef class DelayCellState(CellState):
         self.delay_queue = q
 
 cdef class VolumeCellState(CellState):
-    """
-    A class for keeping track of cell state in a system with volume (species, time, and volume).
-    """
     cdef double volume
     cdef Volume volume_object
     
@@ -281,9 +238,6 @@ cdef class VolumeCellState(CellState):
 
 
 cdef class DelayVolumeCellState(VolumeCellState):
-    """
-    A class for keeping track of cell state in a system with delay and volume (species, time, volume, and queued rxns)
-    """
     cdef DelayQueue delay_queue
 
     cdef inline DelayQueue get_delay_queue(self):
@@ -297,31 +251,18 @@ cdef class DelayVolumeCellState(VolumeCellState):
 #################################################                     ################################################
 
 cdef class VolumeSplitter:
-    """
-    Interface class for defining a method to partition cells for the case with no delay and only volume involved.
-    """
     cdef np.ndarray partition(self, VolumeCellState parent)
 
 cdef class DelayVolumeSplitter:
-    """
-    Interface class for defining a method to partition cells for the case with delay AND volume involved.
-    """
     cdef np.ndarray partition(self, DelayVolumeCellState parent)
 
 
 
 cdef class PerfectBinomialVolumeSplitter(VolumeSplitter):
-    """
-    A volume splitting class that splits the cell into two equal halves and splits the molecuels binomially w/ p = 0.5
-    """
     cdef np.ndarray partition(self, VolumeCellState parent)
 
 
 cdef class GeneralVolumeSplitter(VolumeSplitter):
-    """
-    A volume splitting class that splits the cell into two cells and can split species
-    binomially, perfectly, or by duplication.
-    """
     cdef vector[int] binomial_indices
     cdef vector[int] perfect_indices
     cdef vector[int] duplicate_indices
@@ -331,18 +272,9 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
 
 
 cdef class PerfectBinomialDelayVolumeSplitter(DelayVolumeSplitter):
-    """
-    A class which splits a cell with delays into two equal halves and partitions molecules and queued reactions
-    binomially with p=0.5.
-
-    WARNING: If the queued reactions have negative species updates, this can lead to possible negative species count.
-    """
     cdef np.ndarray partition(self, DelayVolumeCellState parent)
 
 cdef class CustomSplitter(VolumeSplitter):
-    """
-    A volume splitting class that splits the cell into two equal halves and splits the molecuels binomially w/ p = 0.5
-    """
     cdef object split_function
     cdef np.ndarray partition(self, VolumeCellState parent)
 
@@ -353,15 +285,9 @@ cdef class CustomSplitter(VolumeSplitter):
 
 # Regular simulations with no volume or delay involved.
 cdef class RegularSimulator:
-    """
-    Interface class for defining simulators for the regular case with no delay/volume involved
-    """
     cdef SSAResult simulate(self, CSimInterface sim, np.ndarray timepoints)
 
 cdef class DeterministicSimulator(RegularSimulator):
-    """
-    A class for implementing a deterministic simulator.
-    """
     cdef double atol
     cdef double rtol
     cdef double hmax
@@ -391,9 +317,6 @@ cdef class DeterministicDilutionSimulator(RegularSimulator):
 
 
 cdef class SSASimulator(RegularSimulator):
-    """
-    A class for implementing a stochastic SSA simulator.
-    """
     cdef SSAResult simulate(self, CSimInterface sim, np.ndarray timepoints)
 
 cdef class SafeModeSSASimulator(RegularSimulator):
@@ -411,42 +334,24 @@ cdef class TimeDependentSSASimulator(RegularSimulator):
 
 
 cdef class DelaySimulator:
-    """
-    Interface class for defining a simulator with delay.
-    """
     cdef DelaySSAResult delay_simulate(self, CSimInterface sim, DelayQueue dq, np.ndarray timepoints)
 
 cdef class DelaySSASimulator(DelaySimulator):
-    """
-    A class for doing delay simulations using the stochastic simulation algorithm.
-    """
     cdef DelaySSAResult delay_simulate(self, CSimInterface sim, DelayQueue dq, np.ndarray timepoints)
 
 
 
 cdef class VolumeSimulator:
-    """
-    Interface class for doing volume simulations.
-    """
     cdef VolumeSSAResult volume_simulate(self, CSimInterface sim, Volume v, np.ndarray timepoints)
 
 
 cdef class VolumeSSASimulator(VolumeSimulator):
-    """
-    Volume SSA implementation.
-    """
     cdef VolumeSSAResult volume_simulate(self, CSimInterface sim, Volume v, np.ndarray timepoints)
 
 cdef class DelayVolumeSimulator:
-    """
-    Interface class for doing simulations with delay and volume.
-    """
     cdef DelayVolumeSSAResult delay_volume_simulate(self, CSimInterface sim, DelayQueue q,
                                                     Volume v, np.ndarray timepoints)
 
 cdef class DelayVolumeSSASimulator(DelayVolumeSimulator):
-    """
-    SSA implementation for doing simulations with delay and volume.
-    """
     cdef DelayVolumeSSAResult delay_volume_simulate(self, CSimInterface sim, DelayQueue q,
                                                     Volume v, np.ndarray timepoints)

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -2068,7 +2068,16 @@ def rhs_ivp(double t, np.ndarray[np.double_t, ndim=1] state):
 cdef class RegularSimulator:
     """Interface for simulators with no delay or volume involved.
 
-    Must be subclassed.
+    This class is used as a base class for deterministic or
+    stochastic simulators that do not involve delay or volume. The
+    `py_simulate` method is provided with the reaction system to
+    simulate and the timepoints to report results. Must be
+    subclassed.
+
+    See Also
+    --------
+    DeterministicSimulator : Concrete ODE-based implementation.
+    SSASimulator : Concrete stochastic (Gillespie) implementation.
     """
     cdef SSAResult simulate(self, CSimInterface sim, np.ndarray timepoints):
         """
@@ -2105,6 +2114,12 @@ cdef class RegularSimulator:
 
 cdef class DeterministicSimulator(RegularSimulator):
     """A deterministic simulator using `scipy.integrate.odeint`.
+
+    Integrates the model's ODEs -- the deterministic limit of the
+    propensity-based reaction network -- forward in time, retrying
+    with a larger `mxstep` if the integrator fails to converge. Used
+    when `py_simulate_model` is called with `stochastic=False` (the
+    default).
 
     Attributes
     ----------
@@ -2240,8 +2255,14 @@ cdef class DeterministicSimulator(RegularSimulator):
         return self._helper_simulate(sim, timepoints, **keywords)
 
 cdef class SSASimulator(RegularSimulator):
-    """
-    A class for implementing a stochastic SSA simulator.
+    """A stochastic simulator using the Gillespie algorithm (SSA).
+
+    At each step, samples the waiting time to the next reaction from
+    the sum of all propensities, then chooses which reaction fires
+    weighted by its own propensity -- an exact sampling of the
+    chemical master equation, rather than the deterministic ODE
+    approximation. Used when `py_simulate_model` is called with
+    `stochastic=True`.
     """
     cdef SSAResult simulate(self, CSimInterface sim, np.ndarray timepoints):
         cdef np.ndarray[np.double_t,ndim=1] c_timepoints = timepoints
@@ -2313,8 +2334,17 @@ cdef class SSASimulator(RegularSimulator):
 
 
 cdef class DelaySimulator:
-    """
-    Interface class for defining a simulator with delay.
+    """Interface class for defining a simulator with delay.
+
+    This class is used as a base class for deterministic or
+    stochastic simulators that involve delayed reactions. The
+    `py_delay_simulate` method is provided with reaction system to
+    simulate, the initial queue of delayed reactions, and the
+    timepoints to report results. Must be subclassed.
+
+    See Also
+    --------
+    DelaySSASimulator : Concrete implementation.
     """
     cdef DelaySSAResult delay_simulate(self, CSimInterface sim, DelayQueue dq, np.ndarray timepoints):
         """
@@ -2353,8 +2383,13 @@ cdef class DelaySimulator:
 
 
 cdef class DelaySSASimulator(DelaySimulator):
-    """
-    A class for doing delay simulations using the stochastic simulation algorithm.
+    """Stochastic (SSA) simulation with delayed reactions.
+
+    Extends `SSASimulator` so a reaction's effects can be scheduled
+    to complete some time after it fires (via a `Delay` attached to
+    the reaction) instead of immediately, tracking reactions already
+    "in flight" in a `DelayQueue`. Used when `py_simulate_model` is
+    called with `stochastic=True, delay=True`.
     """
     cdef DelaySSAResult delay_simulate(self, CSimInterface sim, DelayQueue q, np.ndarray timepoints):
         # Set up the needed variables in C
@@ -2469,8 +2504,17 @@ cdef class DelaySSASimulator(DelaySimulator):
 
 
 cdef class VolumeSimulator:
-    """
-    Interface class for doing volume simulations.
+    """Interface class for doing volume simulations.
+
+    This class is used as a base class for simulators that track a
+    growing/dividing cell's volume alongside the reaction system. The
+    `py_volume_simulate` method is provided with the reaction system
+    to simulate, the volume model, and the timepoints to report
+    results. Must be subclassed.
+
+    See Also
+    --------
+    VolumeSSASimulator : Concrete implementation.
     """
     cdef VolumeSSAResult volume_simulate(self, CSimInterface sim, Volume v, np.ndarray timepoints):
         """
@@ -2508,8 +2552,14 @@ cdef class VolumeSimulator:
 
 
 cdef class VolumeSSASimulator(VolumeSimulator):
-    """
-    Volume SSA implementation.
+    """Stochastic (SSA) simulation of a growing/dividing cell's volume.
+
+    Extends `SSASimulator` to additionally track a `Volume` alongside
+    species counts, rescaling reaction propensities by the current
+    volume as the cell grows. Used when `py_simulate_model` is called
+    with `stochastic=True, volume=True`; full population/lineage
+    tracking across many divisions is provided by `bioscrape.lineage`
+    instead.
     """
     cdef VolumeSSAResult volume_simulate(self, CSimInterface sim, Volume v, np.ndarray timepoints):
         """
@@ -2624,8 +2674,18 @@ cdef class VolumeSSASimulator(VolumeSimulator):
 
 
 cdef class DelayVolumeSimulator:
-    """
-    Interface class for doing simulations with delay and volume.
+    """Interface class for doing simulations with delay and volume.
+
+    This class is used as a base class for simulators that combine
+    delayed reactions with a growing/dividing cell's volume. The
+    `py_delay_volume_simulate` method is provided with the reaction
+    system to simulate, the initial queue of delayed reactions, the
+    volume model, and the timepoints to report results. Must be
+    subclassed.
+
+    See Also
+    --------
+    DelayVolumeSSASimulator : Concrete implementation.
     """
     cdef DelayVolumeSSAResult delay_volume_simulate(self, CSimInterface sim, DelayQueue q,
                                                     Volume v, np.ndarray timepoints):
@@ -2667,8 +2727,13 @@ cdef class DelayVolumeSimulator:
         return self.delay_volume_simulate(sim,q,v,timepoints)
 
 cdef class DelayVolumeSSASimulator(DelayVolumeSimulator):
-    """
-    SSA implementation for doing simulations with delay and volume.
+    """Stochastic (SSA) simulation combining delay and volume.
+
+    Combines `DelaySSASimulator`'s delayed-reaction scheduling with
+    `VolumeSSASimulator`'s volume tracking and propensity rescaling.
+    (Not currently reachable via `py_simulate_model`'s `delay=True,
+    volume=True` combination due to a separate wiring bug; construct
+    and use this class directly instead.)
     """
     cdef DelayVolumeSSAResult delay_volume_simulate(self, CSimInterface sim, DelayQueue q,
                                                     Volume v, np.ndarray timepoints):
@@ -2815,6 +2880,17 @@ cdef class DelayVolumeSSASimulator(DelayVolumeSimulator):
 def py_simulate_model(timepoints, Model = None, Interface = None, stochastic = False,
                     delay = None, safe = False, volume = False, return_dataframe = True, **keywords):
     """Simulate a bioscrape `Model`.
+
+    Selects and configures the appropriate simulator from the
+    `stochastic`, `delay`, and `volume` flags: deterministic
+    simulation integrates the ODEs with `scipy.integrate.odeint`,
+    stochastic simulation uses Gillespie's Stochastic Simulation
+    Algorithm (SSA), `delay=True` additionally tracks in-flight
+    delayed reactions via a `DelayQueue`, and `volume=True` tracks a
+    growing cell's volume and automatically rescales reaction
+    propensities by it. This is the simplest way to simulate a
+    model; most users should not need to construct a specific
+    simulator class directly.
 
     Parameters
     ----------

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -186,7 +186,7 @@ cdef class ArrayDelayQueue(DelayQueue):
     """A `DelayQueue` backed by an array of future reaction counts.
 
     The max future time that can be handled is
-    ``dt * (number of queue columns)``.
+    dt * (number of queue columns).
 
     Parameters
     ----------
@@ -711,7 +711,7 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
     propensity is set to 0 without evaluating it. Also warns (and
     zeroes out) any propensity that computes as negative, and warns
     if any species count or volume falls outside
-    ``[0, max_species_count]``/``(0, max_volume]`` before computing
+    [0, max_species_count]/(0, max_volume] before computing
     stochastic propensities, instead of silently propagating an
     ill-conditioned value.
 
@@ -1812,6 +1812,7 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
     Splits species binomially, perfectly, or by duplication.
     """
     def __init__(self):
+        """See class docstring."""
         self.partition_noise = 0
 
     def py_set_partitioning(self, dict options, Model m):
@@ -1864,7 +1865,7 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
         """Set the volume-split noise.
 
         The split fraction is drawn uniformly from
-        ``[0.5 - noise, 0.5]`` of the parent's volume rather than
+        [0.5 - noise, 0.5] of the parent's volume rather than
         always splitting exactly in half.
 
         Parameters

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -1,7 +1,11 @@
 # cython: boundscheck=False
 # cython: cdivision=True
 # cython: wraparound=True
+"""
+Deterministic and stochastic simulators for bioscrape models.
 
+See `py_simulate_model` for the main user-facing entry point.
+"""
 import numpy as np
 cimport numpy as np
 cimport random as cyrandom
@@ -19,6 +23,11 @@ import logging
 #################################################                     ################################################
 
 cdef class DelayQueue:
+    """Interface for keeping track of queued delayed reactions.
+
+    Tracks reactions that have fired but won't resolve until some
+    future time. Must be subclassed by delay queue implementations.
+    """
     cdef void add_reaction(self, double time, unsigned rxn_id, double amount):
         """
         Add a reaction to the queue.
@@ -31,6 +40,18 @@ cdef class DelayQueue:
         pass
 
     def py_add_reaction(self,double time, unsigned rxn_id, double amount):
+        """Add a reaction to the queue.
+
+        Parameters
+        ----------
+        time : float
+            The time at which the reaction will occur.
+        rxn_id : unsigned
+            The reaction's ID, i.e. its column index in the
+            stoichiometry matrix.
+        amount : float
+            How many of the reaction occurs.
+        """
         self.add_reaction(time, rxn_id, amount)
 
 
@@ -45,6 +66,17 @@ cdef class DelayQueue:
         return 0.0
 
     def py_get_next_queue_time(self):
+        """Return the nearest queued time.
+
+        Note that it's possible no reaction occurs at this time: the
+        queue may internally update at some fixed time resolution
+        even when no reactions are due.
+
+        Returns
+        -------
+        float
+            The next queue time.
+        """
         return self.get_next_queue_time()
 
     cdef void get_next_reactions(self, double *rxn_array):
@@ -57,6 +89,15 @@ cdef class DelayQueue:
         pass
 
     def py_get_next_reactions(self, np.ndarray[np.double_t, ndim=1] rxn_array):
+        """Fill in how many of each reaction occurs at the next queued time.
+
+        Parameters
+        ----------
+        rxn_array : numpy.ndarray
+            Modified in place to hold the count of each reaction
+            occurring at the next queued time. Must have at least
+            one entry per reaction.
+        """
         self.get_next_reactions(<double*> rxn_array.data)
 
 
@@ -69,6 +110,11 @@ cdef class DelayQueue:
         pass
 
     def py_advance_time(self):
+        """Advance the queue to its next relevant time.
+
+        Call `py_get_next_reactions` before this, or the reactions
+        that occurred at the current queue time will be lost.
+        """
         self.advance_time()
 
 
@@ -80,6 +126,7 @@ cdef class DelayQueue:
         return None
 
     def py_copy(self):
+        """Return a new, totally independent copy of this DelayQueue."""
         return self.copy()
 
 
@@ -92,6 +139,13 @@ cdef class DelayQueue:
         pass
 
     def py_set_current_time(self, double t):
+        """Set the queue's current time.
+
+        Parameters
+        ----------
+        t : float
+            The time to set.
+        """
         self.set_current_time(t)
 
     cdef DelayQueue clear_copy(self):
@@ -102,6 +156,7 @@ cdef class DelayQueue:
         return None
 
     def py_clear_copy(self):
+        """Return a new DelayQueue with the same config but no reactions."""
         return self.clear_copy()
 
     cdef np.ndarray binomial_partition(self, double p):
@@ -112,18 +167,61 @@ cdef class DelayQueue:
         """
         return None
     def py_binomial_partition(self, double p):
+        """Randomly split this queue's reactions into two queues.
+
+        Parameters
+        ----------
+        p : float
+            Binomial probability, ``0 < p < 1``, that a given queued
+            reaction goes to the first of the two output queues.
+
+        Returns
+        -------
+        numpy.ndarray
+            Length-2 array of `DelayQueue` objects.
+        """
         return self.binomial_partition(p)
 
 cdef class ArrayDelayQueue(DelayQueue):
-    def __init__(self, np.ndarray queue, double dt, double current_time):
-        """
-        Initialize with a queue, dt resolution, and current time. The queue should have one row for each reaction and
-        the max future time that can be handled is dt*(number of queue columns).
+    """A `DelayQueue` backed by an array of future reaction counts.
 
-        :param queue: (np.ndarray) 2-D array containing the current time.
-        :param dt: (double) The time resolution dt
-        :param current_time: (double) The current time.
-        """
+    The max future time that can be handled is
+    ``dt * (number of queue columns)``.
+
+    Parameters
+    ----------
+    queue : numpy.ndarray
+        2-D array of future reaction counts (see the `queue`
+        attribute).
+    dt : float
+        The time resolution.
+    current_time : float
+        The current time.
+
+    Attributes
+    ----------
+    dt : float
+        The time resolution.
+    next_queue_time : float
+        The next gridded time point; these are spaced by `dt`.
+    num_cols : unsigned
+        The number of columns in `queue`, i.e. the number of `dt`
+        grid points ahead that are tracked.
+    num_reactions : unsigned
+        The number of reactions in the system, and the number of
+        rows in `queue`.
+    start_index : unsigned
+        The column of `queue` corresponding to `next_queue_time`;
+        cycles around as time advances.
+    queue : numpy.ndarray
+        2-D array whose columns are future time points spaced by
+        `dt` and whose rows are future reaction occurrences for each
+        reaction. `start_index` is the very next time, and each
+        successive column corresponds to `dt` more than the last,
+        wrapping around the end of the array.
+    """
+    def __init__(self, np.ndarray queue, double dt, double current_time):
+        """See class docstring."""
         self.num_reactions = queue.shape[0]
         self.num_cols = queue.shape[1]
         self.queue = queue
@@ -133,13 +231,21 @@ cdef class ArrayDelayQueue(DelayQueue):
 
     @staticmethod
     def setup_queue(unsigned num_reactions, unsigned queue_length, double dt):
-        """
-        Static method to create an empty ArrayDelayQueue given a desired length, number of reactions, and dt.
+        """Create an empty `ArrayDelayQueue`.
 
-        :param num_reactions: (unsigned) number of reactions in the system
-        :param queue_length: (unsigned) length of the queue
-        :param dt: (double) time step
-        :return: The created array delay queue object
+        Parameters
+        ----------
+        num_reactions : unsigned
+            Number of reactions in the system.
+        queue_length : unsigned
+            Number of `dt`-spaced future time points to track.
+        dt : float
+            The time resolution.
+
+        Returns
+        -------
+        ArrayDelayQueue
+            The created queue.
         """
         return ArrayDelayQueue(np.zeros((num_reactions,queue_length)), dt, 0.0)
 
@@ -252,16 +358,24 @@ cdef class ArrayDelayQueue(DelayQueue):
 #################################################                     ################################################
 
 cdef class CSimInterface:
+    """Interface for the stoichiometric matrices and delays of a model.
+
+    Base class for adapting a model (e.g. a `Model`) into the form
+    simulators need. Subclasses must override the propensity/delay
+    computation methods; see `ModelCSimInterface`.
+    """
     cdef np.ndarray get_update_array(self):
         return self.update_array
 
     def py_get_update_array(self):
+        """Return the stoichiometric matrix for immediate changes."""
         return self.get_update_array()
 
 
     cdef np.ndarray get_delay_update_array(self):
         return self.delay_update_array
     def py_get_delay_update_array(self):
+        """Return the stoichiometric matrix for delayed changes."""
         return self.get_delay_update_array()
 
     #Checks model or interface is valid. Meant to be overriden by the subclass
@@ -292,66 +406,77 @@ cdef class CSimInterface:
         return self.initial_state
 
     def py_get_initial_state(self):
+        """Return the initial state vector."""
         return self.get_initial_state()
 
     cdef void set_initial_state(self, np.ndarray a):
         self.initial_state = a
 
     def py_set_initial_state(self, np.ndarray a):
+        """Set the initial state vector."""
         self.set_initial_state(a)
 
     cdef unsigned get_num_reactions(self):
         return self.num_reactions
 
     def py_get_num_reactions(self):
+        """Return the number of reactions."""
         return self.get_num_reactions()
 
     cdef unsigned get_num_species(self):
         return self.num_species
 
     def py_get_num_species(self):
+        """Return the number of species."""
         return self.get_num_species()
 
     cdef double get_initial_time(self):
         return self.initial_time
 
     def py_get_initial_time(self):
+        """Return the initial simulation time."""
         return self.get_initial_time()
 
     cdef void set_initial_time(self, double t):
         self.initial_time = t
 
     def py_set_initial_time(self, double t):
+        """Set the initial simulation time."""
         self.set_initial_time(t)
 
     cdef void set_dt(self, double dt):
         self.dt = dt
 
     def py_set_dt(self, double dt):
+        """Set the simulation time step."""
         self.set_dt(dt)
 
     cdef double get_dt(self):
         return self.dt
 
     def py_get_dt(self):
+        """Return the simulation time step."""
         return self.get_dt()
 
     cdef double* get_param_values(self):
         return <double*> 0
 
     def py_get_param_values(self):
+        """Return the parameter values (None; override in subclasses)."""
         return None
 
     cdef unsigned get_num_parameters(self):
         return 0
 
     def py_get_num_parameters(self):
+        """Return the number of parameters (0; override in subclasses)."""
         return self.get_num_parameters()
 
     cdef unsigned get_number_of_rules(self):
         return 0
 
     def py_get_number_of_rules(self):
+        """Return the number of rules (0; override in subclasses)."""
         return self.get_number_of_rules()
 
     cdef void apply_repeated_rules(self, double *state, double time, unsigned rule_step):
@@ -361,9 +486,37 @@ cdef class CSimInterface:
         pass
 
     def py_apply_repeated_rules(self, np.ndarray[np.double_t, ndim=1] state, double time=0.0, rule_step = True):
+        """Apply the model's rules to a state vector, in place.
+
+        A no-op in the base class; overridden in subclasses.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector, modified in place.
+        time : float, default 0.0
+            The current simulation time.
+        rule_step : bool, default True
+            Whether this call lands on a rule-application step.
+        """
         self.apply_repeated_rules(<double*> state.data,time, rule_step)
 
     def py_apply_repeated_volume_rules(self, np.ndarray[np.double_t, ndim=1] state, double volume = 1.0, double time=0.0, rule_step = True):
+        """Apply the model's volume-dependent rules, in place.
+
+        A no-op in the base class; overridden in subclasses.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector, modified in place.
+        volume : float, default 1.0
+            The current cell volume.
+        time : float, default 0.0
+            The current simulation time.
+        rule_step : bool, default True
+            Whether this call lands on a rule-application step.
+        """
         self.apply_repeated_volume_rules(<double*> state.data, volume, time, rule_step)
 
 
@@ -391,6 +544,12 @@ cdef class CSimInterface:
         global_sim = self
 
     def py_prep_deterministic_simulation(self):
+        """Prepare this interface for deterministic simulation.
+
+        Builds the compressed stoichiometry matrix and propensity
+        buffer used by `py_calculate_deterministic_derivative`. Must
+        be called once before running a deterministic simulation.
+        """
         self.prep_deterministic_simulation()
 
     # Compute deterministic derivative
@@ -409,12 +568,37 @@ cdef class CSimInterface:
 
     def py_calculate_deterministic_derivative(self, np.ndarray[np.double_t,ndim=1] x, np.ndarray[np.double_t,ndim=1] dx,
                                               double t):
+        """Compute the deterministic ODE derivative dx/dt at state x.
+
+        `py_prep_deterministic_simulation` must be called first.
+
+        Parameters
+        ----------
+        x : numpy.ndarray
+            The state vector.
+        dx : numpy.ndarray
+            Modified in place to hold the computed derivative.
+        t : float
+            The current simulation time.
+        """
         self.calculate_deterministic_derivative(<double*> x.data, <double*> dx.data, t)
 
 
 
 cdef class ModelCSimInterface(CSimInterface):
+    """A `CSimInterface` backed by a bioscrape `Model`.
+
+    Extracts the propensities, delays, rules, and stoichiometric
+    matrices from `external_model` for use by the simulators.
+
+    Parameters
+    ----------
+    external_model : Model
+        The model to wrap. Initialized automatically (see
+        `Model.py_initialize`) if it isn't already.
+    """
     def __init__(self, external_model):
+        """See class docstring."""
         self.model = external_model
         #Check Model and initialization
         if not self.model.initialized:
@@ -493,9 +677,23 @@ cdef class ModelCSimInterface(CSimInterface):
         self.c_param_values = <double*>(self.np_param_values.data)
 
     def py_get_param_values(self):
+        """Return the parameter values."""
         return self.np_param_values
 
     def py_set_param_values(self, params):
+        """Set the parameter values.
+
+        Parameters
+        ----------
+        params : numpy.ndarray
+            The new parameter values; must be the same length as the
+            current parameter values.
+
+        Raises
+        ------
+        ValueError
+            If `params` is not the expected length.
+        """
         if len(params) != len(self.np_param_values):
             raise ValueError(f"params must be a numpy array of length {len(self.np_param_values)}. Recieved {params}.")
         self.np_param_values = params
@@ -506,7 +704,28 @@ cdef class ModelCSimInterface(CSimInterface):
         return self.np_param_values.shape[0]
 
 cdef class SafeModelCSimInterface(ModelCSimInterface):
+    """A `ModelCSimInterface` with extra validity checks.
+
+    Before computing a reaction's propensity, checks that its
+    reactant species have enough copies available; if not, the
+    propensity is set to 0 without evaluating it. Also warns (and
+    zeroes out) any propensity that computes as negative, and warns
+    if any species count or volume falls outside
+    ``[0, max_species_count]``/``(0, max_volume]`` before computing
+    stochastic propensities, instead of silently propagating an
+    ill-conditioned value.
+
+    Parameters
+    ----------
+    external_model : Model
+        The model to wrap.
+    max_volume : float, default 10000
+        Upper bound on volume before a warning is issued.
+    max_species_count : float, default 10000
+        Upper bound on a species count before a warning is issued.
+    """
     def __init__(self, external_model, max_volume = 10000, max_species_count = 10000):
+        """See class docstring."""
         self.max_volume = max_volume
         self.max_species_count = max_species_count
         super().__init__(external_model)
@@ -646,18 +865,45 @@ cdef class SafeModelCSimInterface(ModelCSimInterface):
 
 
 cdef class SSAResult:
+    """The result of a simulation: timepoints and species over time.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray
+        1-D array of the simulation's time points.
+    result : numpy.ndarray
+        2-D array of species values, one row per timepoint, one
+        column per species.
+    """
     def __init__(self, np.ndarray timepoints, np.ndarray result):
+        """See class docstring."""
         self.timepoints = timepoints
         self.simulation_result = result
 
     def py_get_timepoints(self):
+        """Return the 1-D array of simulation time points."""
         return self.get_timepoints()
 
     def py_get_result(self):
+        """Return the 2-D array of species values over time."""
         return self.get_result()
 
     #Returns a Pandas Data Frame, if it is installed. If not, a Numpy array is returned.
     def py_get_dataframe(self, Model = None):
+        """Return this result's data as a pandas DataFrame.
+
+        Parameters
+        ----------
+        Model : Model, optional
+            If given, used to label the data columns with species
+            names. Otherwise the columns are left unnamed.
+
+        Returns
+        -------
+        pandas.DataFrame or numpy.ndarray
+            The species values and time as a DataFrame, or (if
+            pandas is not installed) the raw result array.
+        """
         try:
             import pandas
             if Model == None:
@@ -675,15 +921,34 @@ cdef class SSAResult:
 
 
     def py_empirical_distribution(self, start_time = None, species = None, Model = None, final_time = None, max_counts = None):
-        """
-            calculates the empirical distribution of a trajectory over counts
-            start_time: the time to begin the empirical calculation
-            final_time: time to end the empirical marginalization
-            species: the list of species inds or names to calculate over. Marginalizes over non-included species
-            max_counts: a list (size N-species) of the maximum count expected for each species. 
-                 If max_counts[i] == 0, defaults to the maximum count found in the simulation: max(results[:, i]).
-                 Useful for getting distributions of a specific size/shape.
-            Model: the model used to produce the results. Required if species are referenced by name isntead of index
+        """Compute the empirical distribution of a trajectory over counts.
+
+        Parameters
+        ----------
+        start_time : float, optional
+            Time to begin the calculation. Defaults to the first
+            simulation timepoint.
+        species : list of int or str, optional
+            Species (by index or name) to calculate over. Species
+            not included are marginalized out. Defaults to all
+            species.
+        Model : Model, optional
+            The model used to produce these results. Required if
+            `species` are given by name instead of index.
+        final_time : float, optional
+            Time to end the calculation. Defaults to the last
+            simulation timepoint.
+        max_counts : list of int, optional
+            Maximum count expected for each species in `species`. If
+            an entry is 0, it defaults to the maximum count observed
+            in the simulation for that species. Useful for getting
+            distributions of a specific size/shape.
+
+        Returns
+        -------
+        numpy.ndarray
+            The empirical distribution, with one axis per requested
+            species, sized `max_counts`.
         """
         if species is None:
             species_inds = [i for i in range(self.simulation_result.shape[1])]
@@ -760,12 +1025,27 @@ cdef class SSAResult:
 
     #Python wrapper of a fast cython function to compute the first moment (mean) of a set of Species
     def py_first_moment(self, start_time = None, species = None, Model = None, final_time = None):
-        """
-            calculates the first moment (mean) of a trajectory over counts
-            start_time: the time to begin the empirical calculation
-            final_time: time to end the empirical marginalization
-            species: the list of species inds or names to calculate over. Marginalizes over non-included species
-            Model: the model used to produce the results. Required if species are referenced by name isntead of index
+        """Compute the first moment (mean) of a trajectory over counts.
+
+        Parameters
+        ----------
+        start_time : float, optional
+            Time to begin the calculation. Defaults to the first
+            simulation timepoint.
+        species : list of int or str, optional
+            Species (by index or name) to calculate over. Defaults
+            to all species.
+        Model : Model, optional
+            The model used to produce these results. Required if
+            `species` are given by name instead of index.
+        final_time : float, optional
+            Time to end the calculation. Defaults to the last
+            simulation timepoint.
+
+        Returns
+        -------
+        numpy.ndarray
+            The mean of each requested species over the time window.
         """
 
         if species is None:
@@ -813,12 +1093,28 @@ cdef class SSAResult:
 
     #Python wrapper of a fast cython function to compute the standard deviation of a set of Species
     def py_standard_deviation(self, start_time = None, species = None, Model = None, final_time = None):
-        """
-            calculates the standard deviation of a trajectory over counts
-            start_time: the time to begin the empirical calculation
-            final_time: time to end the empirical marginalization
-            species: the list of species inds or names to calculate over. Marginalizes over non-included species
-            Model: the model used to produce the results. Required if species are referenced by name isntead of index
+        """Compute the standard deviation of a trajectory over counts.
+
+        Parameters
+        ----------
+        start_time : float, optional
+            Time to begin the calculation. Defaults to the first
+            simulation timepoint.
+        species : list of int or str, optional
+            Species (by index or name) to calculate over. Defaults
+            to all species.
+        Model : Model, optional
+            The model used to produce these results. Required if
+            `species` are given by name instead of index.
+        final_time : float, optional
+            Time to end the calculation. Defaults to the last
+            simulation timepoint.
+
+        Returns
+        -------
+        numpy.ndarray
+            The standard deviation of each requested species over
+            the time window.
         """
         if species is None:
             species_inds = [i for i in range(self.simulation_result.shape[1])]
@@ -866,13 +1162,33 @@ cdef class SSAResult:
 
     #Computes the correlations between species1 and species2
     def py_correlations(self, start_time = None, species1 = None, species2 = None, final_time = None, Model = None):
-        """
-            calculates the pairwise correlations (species1 x species2) of a trajectory over counts
-            start_time: the time to begin the empirical calculation
-            final_time: time to end the empirical marginalization
-            species1: a list of species names or indices. If None, defaults to all species.
-            species2: a second list of species indices or names. All pairs between species1 and species2 are computed
-            Model: the model used to produce the results. Required if species are referenced by name isntead of index
+        """Compute pairwise correlations between two lists of species.
+
+        Parameters
+        ----------
+        start_time : float, optional
+            Time to begin the calculation. Defaults to the first
+            simulation timepoint.
+        species1 : list of int or str, optional
+            First list of species (by index or name). Defaults to
+            all species.
+        species2 : list of int or str, optional
+            Second list of species (by index or name); all pairs
+            between `species1` and `species2` are computed. Defaults
+            to all species.
+        final_time : float, optional
+            Time to end the calculation. Defaults to the last
+            simulation timepoint.
+        Model : Model, optional
+            The model used to produce these results. Required if
+            `species1`/`species2` are given by name instead of
+            index.
+
+        Returns
+        -------
+        numpy.ndarray
+            2-D array of correlations, indexed by `species1` and
+            `species2`.
         """
 
         if species1 is None:
@@ -938,13 +1254,33 @@ cdef class SSAResult:
 
     #Python wrapper of a fast cython function to compute the second moment (E[S1*S2]) pairwise between two lists of species
     def py_second_moment(self, start_time = None, species1 = None, species2 = None, final_time = None, Model = None):
-        """
-            calculates the pairwise second moments of a trajectory over counts
-            start_time: the time to begin the empirical calculation
-            final_time: time to end the empirical marginalization
-            species1: a list of species names or indices. If None, defaults to all species.
-            species2: a second list of species indices or names. All pairs between species1 and species2 are computed
-            Model: the model used to produce the results. Required if species are referenced by name isntead of index
+        """Compute pairwise second moments (E[S1*S2]) of two species lists.
+
+        Parameters
+        ----------
+        start_time : float, optional
+            Time to begin the calculation. Defaults to the first
+            simulation timepoint.
+        species1 : list of int or str, optional
+            First list of species (by index or name). Defaults to
+            all species.
+        species2 : list of int or str, optional
+            Second list of species (by index or name); all pairs
+            between `species1` and `species2` are computed. Defaults
+            to all species.
+        final_time : float, optional
+            Time to end the calculation. Defaults to the last
+            simulation timepoint.
+        Model : Model, optional
+            The model used to produce these results. Required if
+            `species1`/`species2` are given by name instead of
+            index.
+
+        Returns
+        -------
+        numpy.ndarray
+            2-D array of second moments, indexed by `species1` and
+            `species2`.
         """
 
         if species1 is None:
@@ -1005,26 +1341,76 @@ cdef class SSAResult:
         return moments
 
 cdef class DelaySSAResult(SSAResult):
+    """The result of a delay simulation.
+
+    Timepoints and species over time, plus the final set of queued
+    (not-yet-resolved) delayed reactions.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray
+        1-D array of the simulation's time points.
+    result : numpy.ndarray
+        2-D array of species values, one row per timepoint, one
+        column per species.
+    queue : DelayQueue
+        The queue's state at the end of the simulation.
+    """
     def __init__(self, np.ndarray timepoints, np.ndarray result, DelayQueue queue):
+        """See class docstring."""
         self.final_delay_queue = queue
         self.simulation_result = result
 
     def py_get_delay_queue(self):
+        """Return the DelayQueue's state at the end of the simulation."""
         return self.get_delay_queue()
 
 
 cdef class VolumeSSAResult(SSAResult):
+    """The result of a volume simulation.
+
+    Timepoints and species/volume over time.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray
+        1-D array of the simulation's time points.
+    result : numpy.ndarray
+        2-D array of species values, one row per timepoint, one
+        column per species.
+    volume : numpy.ndarray
+        1-D array of the cell volume at each timepoint.
+    divided : unsigned
+        Whether the cell divided during the simulation.
+    """
     def __init__(self,np.ndarray timepoints,np.ndarray result,np.ndarray volume,unsigned divided):
+        """See class docstring."""
         super().__init__(timepoints, result)
         self.volume = volume
         self.cell_divided_flag = divided
 
     def py_cell_divided(self):
+        """Return whether the cell divided during the simulation."""
         return self.cell_divided()
     def py_get_volume(self):
+        """Return the 1-D array of cell volume at each timepoint."""
         return self.get_volume()
 
     def py_get_dataframe(self, Model = None):
+        """Return this result's data as a pandas DataFrame.
+
+        Parameters
+        ----------
+        Model : Model, optional
+            If given, used to label the data columns with species
+            names. Otherwise the columns are left unnamed.
+
+        Returns
+        -------
+        pandas.DataFrame or numpy.ndarray
+            The species values, volume, and time as a DataFrame, or
+            (if pandas is not installed) the raw result array.
+        """
         df = super().py_get_dataframe(Model = Model)
         try:
             import pandas
@@ -1048,21 +1434,44 @@ cdef class VolumeSSAResult(SSAResult):
         return cs
 
     def py_get_final_cell_state(self):
+        """Return the `VolumeCellState` at the end of the simulation."""
         return self.get_final_cell_state()
 
     cdef Schnitz get_schnitz(self):
         return Schnitz(self.timepoints,self.simulation_result,self.volume)
 
     def py_get_schnitz(self):
+        """Return this result as a `Schnitz`."""
         return self.get_schnitz()
 
 
 cdef class DelayVolumeSSAResult(VolumeSSAResult):
+    """The result of a simulation with delay and volume.
+
+    Timepoints and species/volume over time, plus the final set of
+    queued (not-yet-resolved) delayed reactions.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray
+        1-D array of the simulation's time points.
+    result : numpy.ndarray
+        2-D array of species values, one row per timepoint, one
+        column per species.
+    volume : numpy.ndarray
+        1-D array of the cell volume at each timepoint.
+    queue : DelayQueue
+        The queue's state at the end of the simulation.
+    divided : unsigned
+        Whether the cell divided during the simulation.
+    """
     def __init__(self,np.ndarray timepoints, np.ndarray result, np.ndarray volume, DelayQueue queue, unsigned divided):
+        """See class docstring."""
         super().__init__(timepoints, result, volume, divided)
         self.final_delay_queue = queue
 
     def py_get_delay_queue(self):
+        """Return the DelayQueue's state at the end of the simulation."""
         return self.get_delay_queue()
 
     cdef VolumeCellState get_final_cell_state(self):
@@ -1078,29 +1487,68 @@ cdef class DelayVolumeSSAResult(VolumeSSAResult):
 # Cell state classes
 
 cdef class CellState:
+    """A simple cell state: species values and time.
+
+    Parameters
+    ----------
+    time : float, optional
+        The state's time.
+    state : numpy.ndarray, optional
+        The species values.
+    """
     def __init__(self, time = None, state = None):
+        """See class docstring."""
         if time is not None:
             self.py_set_time(time)
         if state is not None:
             self.py_set_state(state)
 
     def py_set_state(self, np.ndarray state):
+        """Set the species values."""
         self.state = state
 
     def py_get_state(self):
+        """Return the species values."""
         return self.state
 
     def py_set_time(self, double t):
+        """Set the state's time."""
         self.time = t
 
     def py_get_time(self):
+        """Return the state's time."""
         return self.time
 
     def py_set_species(self, model, specie, value):
+        """Set the value of one species.
+
+        Parameters
+        ----------
+        model : Model
+            The model used to look up `specie`'s index.
+        specie : str
+            The species name.
+        value : float
+            The value to set.
+        """
         ind = model.get_species_index(specie)
         self.state[ind] = value
 
     def py_get_dataframe(self, Model = None):
+        """Return this state's data as a pandas DataFrame.
+
+        Parameters
+        ----------
+        Model : Model, optional
+            If given, used to label the data columns with species
+            names. Otherwise the columns are left unnamed.
+
+        Returns
+        -------
+        pandas.DataFrame or numpy.ndarray
+            The species values and time as a one-row DataFrame, or
+            (if pandas is not installed) the raw state array.
+        """
         try:
             import pandas
             if Model == None:
@@ -1118,19 +1566,50 @@ cdef class CellState:
             return self.state
 
 cdef class DelayCellState(CellState):
+    """A cell state in a delay system: species, time, and queue.
+
+    Parameters
+    ----------
+    time : float, optional
+        The state's time.
+    state : numpy.ndarray, optional
+        The species values.
+    queue : DelayQueue, optional
+        The queue of not-yet-resolved delayed reactions.
+    """
     def __init__(self, time = None, state = None, queue = None):
+        """See class docstring."""
         super().__init__(time, state)
         if queue is not None:
             self.py_set_delay_queue(queue)
 
     def py_get_delay_queue(self):
+        """Return the queue of not-yet-resolved delayed reactions."""
         return self.delay_queue
 
     def py_set_delay_queue(self, DelayQueue q):
+        """Set the queue of not-yet-resolved delayed reactions."""
         self.delay_queue = q
 
 cdef class VolumeCellState(CellState):
+    """A cell state in a system with volume: species, time, volume.
+
+    Parameters
+    ----------
+    time : float, optional
+        The state's time.
+    state : numpy.ndarray, optional
+        The species values.
+    volume : float or Volume, optional
+        The cell volume, or a `Volume` object to derive it from.
+
+    Raises
+    ------
+    TypeError
+        If `volume` is given and is neither a `float` nor a `Volume`.
+    """
     def __init__(self, time = None, state = None, volume = None):
+        """See class docstring."""
         super().__init__(time, state)
         self.volume_object = None
         if volume is not None:
@@ -1142,15 +1621,19 @@ cdef class VolumeCellState(CellState):
                 raise TypeError(f"VolumeCellState volume argument must be a double or Volume (was {type(volume)}.")
 
     def py_set_volume(self, double volume):
+        """Set the cell volume."""
         self.volume = volume
 
     def py_get_volume(self):
+        """Return the cell volume."""
         return self.volume
 
     def py_set_volume_object(self, Volume v):
+        """Set the `Volume` object associated with this state."""
         self.volume_object = v
 
     def py_get_volume_object(self):
+        """Return the `Volume` object associated with this state."""
         return self.volume_object
 
     def __setstate__(self, state):
@@ -1162,6 +1645,21 @@ cdef class VolumeCellState(CellState):
         return (self.time, self.volume, self.state)
 
     def py_get_dataframe(self, Model = None):
+        """Return this state's data as a pandas DataFrame.
+
+        Parameters
+        ----------
+        Model : Model, optional
+            If given, used to label the data columns with species
+            names. Otherwise the columns are left unnamed.
+
+        Returns
+        -------
+        pandas.DataFrame or numpy.ndarray
+            The species values, volume, and time as a one-row
+            DataFrame, or (if pandas is not installed) the raw state
+            array from `CellState.py_get_dataframe`, unchanged.
+        """
         df = super().py_get_dataframe(Model = Model)
         try:
             import pandas
@@ -1174,15 +1672,34 @@ cdef class VolumeCellState(CellState):
 
 # DEV NOTE: Should be able to just inherit from DelayCellState as well as here, right?
 cdef class DelayVolumeCellState(VolumeCellState):
+    """A cell state with both delay and volume.
+
+    Species, time, volume, and the queue of not-yet-resolved delayed
+    reactions.
+
+    Parameters
+    ----------
+    time : float, optional
+        The state's time.
+    state : numpy.ndarray, optional
+        The species values.
+    volume : float or Volume, optional
+        The cell volume, or a `Volume` object to derive it from.
+    queue : DelayQueue, optional
+        The queue of not-yet-resolved delayed reactions.
+    """
     def __init__(self, time = None, state = None, volume = None, queue = None):
+        """See class docstring."""
         super().__init__(time, state, volume)
         if queue is not None:
             self.py_set_delay_queue(queue)
 
     def py_get_delay_queue(self):
+        """Return the queue of not-yet-resolved delayed reactions."""
         return self.delay_queue
 
     def py_set_delay_queue(self, DelayQueue q):
+        """Set the queue of not-yet-resolved delayed reactions."""
         self.delay_queue = q
 
 
@@ -1191,6 +1708,10 @@ cdef class DelayVolumeCellState(VolumeCellState):
 #################################################                     ################################################
 
 cdef class VolumeSplitter:
+    """Interface for partitioning a cell (no delay, volume only).
+
+    Must be subclassed.
+    """
     cdef np.ndarray partition(self, VolumeCellState parent):
         """
         Split the parent state into two VolumeCellState's.
@@ -1202,19 +1723,53 @@ cdef class VolumeSplitter:
         raise NotImplementedError('partition() not implemented for VolumeSplitter')
 
     def py_partition(self, VolumeCellState parent):
+        """Split a parent cell state into two daughter states.
+
+        Parameters
+        ----------
+        parent : VolumeCellState
+            The cell state to split.
+
+        Returns
+        -------
+        tuple of VolumeCellState
+            The two daughter cell states.
+        """
         cdef np.ndarray ans = self.partition(parent)
         return <VolumeCellState> (ans[0]), <VolumeCellState> (ans[1])
 
 cdef class DelayVolumeSplitter:
+    """Interface for partitioning a cell (with delay and volume).
+
+    Must be subclassed.
+    """
     cdef np.ndarray partition(self, DelayVolumeCellState parent):
         raise NotImplementedError('partition() not implemented for DelayVolumeSplitter')
 
     def py_partition(self, DelayVolumeCellState parent):
+        """Split a parent cell state into two daughter states.
+
+        Parameters
+        ----------
+        parent : DelayVolumeCellState
+            The cell state to split.
+
+        Returns
+        -------
+        tuple of DelayVolumeCellState
+            The two daughter cell states.
+        """
         cdef np.ndarray ans = self.partition(parent)
         return <DelayVolumeCellState> (ans[0]), <DelayVolumeCellState> (ans[1])
 
 
 cdef class PerfectBinomialVolumeSplitter(VolumeSplitter):
+    """Splits a cell into two equal halves, molecules binomially.
+
+    Volume is split exactly in half; each molecule of each species
+    independently goes to one daughter or the other with probability
+    0.5.
+    """
     cdef np.ndarray partition(self, VolumeCellState parent):
         # set up daughters d and e
         cdef VolumeCellState d = VolumeCellState()
@@ -1261,13 +1816,20 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
         self.partition_noise = 0
 
     def py_set_partitioning(self, dict options, Model m):
-        """
-        Set how each species is partitioned.
-        :param options(dict: str -> [str]): A dictionary where keys specify partioning mode and values are lists of
-         species partitioned using that mode. "perfect" means partitioned perfectly +/- 0.5 to maintain round numbers.
-         "binomial" means partitioned binomially. "duplicate" means the species is duplicated with the same number into
-         each daughter cell.
-        :return: None
+        """Set how each species is partitioned between daughter cells.
+
+        Parameters
+        ----------
+        options : dict of str to list of str
+            Maps a partitioning mode to the species names using it.
+            ``'perfect'`` splits a species as evenly as possible
+            (+/- 0.5, keeping round numbers); ``'binomial'`` splits
+            it binomially; ``'duplicate'`` gives each daughter the
+            same count as the parent. Species not listed under
+            ``'perfect'`` or ``'duplicate'`` default to
+            ``'binomial'``.
+        m : Model
+            The model used to look up species indices.
         """
 
         # clear vectors
@@ -1300,10 +1862,17 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
 
 
     def py_set_partition_noise(self, double noise):
-        """
-        Set the noise, pick a uniform volume that is anywhere from 0.5 - noise to 0.5 of the original volume.
-        :param noise: the noise param, should be < 0.5, ideally probably something like 0.05 to 0.1
-        :return: none
+        """Set the volume-split noise.
+
+        The split fraction is drawn uniformly from
+        ``[0.5 - noise, 0.5]`` of the parent's volume rather than
+        always splitting exactly in half.
+
+        Parameters
+        ----------
+        noise : float
+            The noise parameter; should be < 0.5, typically around
+            0.05 to 0.1.
         """
         self.partition_noise = noise
 
@@ -1374,6 +1943,17 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
 
 
 cdef class PerfectBinomialDelayVolumeSplitter(DelayVolumeSplitter):
+    """Splits a cell with delays into two equal halves, binomially.
+
+    Volume, molecules, and queued (not-yet-resolved) delayed
+    reactions are all split binomially with p=0.5.
+
+    Warnings
+    --------
+    If a queued reaction has a negative species update, splitting it
+    binomially can leave a daughter cell with a negative species
+    count.
+    """
     cdef np.ndarray partition(self, DelayVolumeCellState parent):
         # set up daughters d and e
         cdef DelayVolumeCellState d = DelayVolumeCellState()
@@ -1422,7 +2002,17 @@ cdef class PerfectBinomialDelayVolumeSplitter(DelayVolumeSplitter):
 
 
 cdef class CustomSplitter(VolumeSplitter):
+    """Splits a cell using a user-supplied function.
+
+    Parameters
+    ----------
+    split_function : callable
+        Called as ``split_function(parent)`` with the parent
+        `VolumeCellState`; must return a length-2 array of the two
+        daughter `VolumeCellState` objects.
+    """
     def __init__(self, split_function):
+        """See class docstring."""
         self.split_function = split_function
 
     cdef np.ndarray partition(self, VolumeCellState parent):
@@ -1476,6 +2066,10 @@ def rhs_ivp(double t, np.ndarray[np.double_t, ndim=1] state):
 
 # Regular simulations with no volume or delay involved.
 cdef class RegularSimulator:
+    """Interface for simulators with no delay or volume involved.
+
+    Must be subclassed.
+    """
     cdef SSAResult simulate(self, CSimInterface sim, np.ndarray timepoints):
         """
         Perform a simple regular stochastic simulation with no delay or volume involved.
@@ -1488,29 +2082,69 @@ cdef class RegularSimulator:
         raise NotImplementedError("simulate function not implemented for RegularSimulator")
 
     def py_simulate(self, CSimInterface sim, np.ndarray timepoints):
+        """Run a simulation with no delay or volume involved.
+
+        Parameters
+        ----------
+        sim : CSimInterface
+            The reaction system to simulate. Must have its initial
+            time set.
+        timepoints : numpy.ndarray
+            The time points to report results at (must be after the
+            initial time).
+
+        Returns
+        -------
+        SSAResult
+            The simulation result.
+        """
         #suggested that interfaces do some error checking on themselves to prevent kernel crashes.
         sim.check_interface()
         return self.simulate(sim,timepoints)
 
 
 cdef class DeterministicSimulator(RegularSimulator):
-    """
-    A class for implementing a deterministic simulator.
+    """A deterministic simulator using `scipy.integrate.odeint`.
+
+    Attributes
+    ----------
+    atol : float
+        Absolute error tolerance for the ODE integrator.
+    rtol : float
+        Relative error tolerance for the ODE integrator.
+    mxstep : unsigned
+        Maximum number of integrator steps to allow, growing from an
+        initial attempt of 500 by 10x each retry until this cap.
+    hmax : float
+        Maximum step size to use during simulation (0 means
+        unlimited).
     """
 
     def __init__(self):
+        """See class docstring."""
         self.atol = 1.49012e-8
         self.rtol = 1.49012e-8
         self.mxstep = 500000
         self.hmax = 0 #Maximum step to use during simulation
 
     def py_set_tolerance(self, double atol, double rtol):
+        """Set the ODE integrator's absolute and relative tolerance.
+
+        Parameters
+        ----------
+        atol : float
+            Absolute error tolerance.
+        rtol : float
+            Relative error tolerance.
+        """
         self.set_tolerance(atol, rtol)
 
     def py_set_mxstep(self, unsigned mxstep):
+        """Set the maximum number of ODE integrator steps to allow."""
         self.mxstep = mxstep
 
     def py_set_hmax(self, double hmax):
+        """Set the maximum ODE integrator step size (0 = unlimited)."""
         self.hmax = hmax
 
     def _helper_simulate(self, CSimInterface sim, np.ndarray timepoints, **keywords):
@@ -1580,6 +2214,27 @@ cdef class DeterministicSimulator(RegularSimulator):
         return self._helper_simulate(sim,timepoints)
 
     def py_simulate(self, CSimInterface sim, np.ndarray timepoints, **keywords):
+        """Run a deterministic simulation.
+
+        Parameters
+        ----------
+        sim : CSimInterface
+            The reaction system to simulate. Must have its initial
+            time set.
+        timepoints : numpy.ndarray
+            The time points to report results at (must be after the
+            initial time).
+        **keywords
+            Additional keyword arguments forwarded to
+            `scipy.integrate.odeint` (e.g. `atol`, `rtol`, `hmax`,
+            overriding the instance's own settings for this call).
+
+        Returns
+        -------
+        SSAResult
+            The simulation result. If the integrator fails even at
+            `mxstep`, the result's values are all `numpy.nan`.
+        """
         #suggested that interfaces do some error checking on themselves to prevent kernel crashes.
         sim.check_interface()
         return self._helper_simulate(sim, timepoints, **keywords)
@@ -1675,6 +2330,24 @@ cdef class DelaySimulator:
         raise NotImplementedError("Did not implement simulate function for DelaySimulator")
 
     def py_delay_simulate(self, CSimInterface sim, DelayQueue dq, np.ndarray timepoints):
+        """Run a delay SSA simulation.
+
+        Parameters
+        ----------
+        sim : CSimInterface
+            The reaction system to simulate. Must have its initial
+            time set.
+        dq : DelayQueue
+            The initial queue of delayed reactions.
+        timepoints : numpy.ndarray
+            The time points to report results at (must be after the
+            initial time).
+
+        Returns
+        -------
+        DelaySSAResult
+            The simulation result.
+        """
         sim.check_interface()
         return self.delay_simulate(sim,dq,timepoints)
 
@@ -1812,6 +2485,24 @@ cdef class VolumeSimulator:
         raise NotImplementedError("Did not implement simulation function for Volume Simulator")
 
     def py_volume_simulate(self, CSimInterface sim, Volume v, np.ndarray timepoints):
+        """Run a simulation with a growing/dividing cell volume.
+
+        Parameters
+        ----------
+        sim : CSimInterface
+            The reaction system to simulate. Must be initialized to
+            the same time as `v`.
+        v : Volume
+            The volume model, initialized to the same time as `sim`.
+        timepoints : numpy.ndarray
+            The time points to report results at (the first must be
+            >= the initial time).
+
+        Returns
+        -------
+        VolumeSSAResult
+            The simulation result.
+        """
         sim.check_interface()
         return self.volume_simulate(sim,v,timepoints)
 
@@ -1952,6 +2643,26 @@ cdef class DelayVolumeSimulator:
         raise NotImplementedError("Did not implement simulation function for delay/volume simulator.")
 
     def py_delay_volume_simulate(self,CSimInterface sim, DelayQueue q, Volume v, np.ndarray timepoints):
+        """Run a simulation with both delay and a growing/dividing volume.
+
+        Parameters
+        ----------
+        sim : CSimInterface
+            The reaction system to simulate. Must be initialized to
+            the same time as `q` and `v`.
+        q : DelayQueue
+            The initial queue of delayed reactions.
+        v : Volume
+            The volume model, initialized to the same time as `sim`.
+        timepoints : numpy.ndarray
+            The time points to report results at (the first must be
+            >= the initial time).
+
+        Returns
+        -------
+        DelayVolumeSSAResult
+            The simulation result.
+        """
         sim.check_interface()
         return self.delay_volume_simulate(sim,q,v,timepoints)
 
@@ -2101,34 +2812,58 @@ cdef class DelayVolumeSSASimulator(DelayVolumeSimulator):
 
 
 #A wrapper function to allow easy simulation of Models
-def py_simulate_model(timepoints, Model = None, Interface = None, stochastic = False, 
+def py_simulate_model(timepoints, Model = None, Interface = None, stochastic = False,
                     delay = None, safe = False, volume = False, return_dataframe = True, **keywords):
+    """Simulate a bioscrape `Model`.
+
+    Parameters
+    ----------
+    timepoints : numpy.ndarray
+        The times to report simulation results at.
+    Model : Model, optional
+        The bioscrape model to simulate. Exactly one of `Model` or
+        `Interface` must be given.
+    Interface : CSimInterface, optional
+        A specific simulation interface to use instead of building
+        one from `Model`. Exactly one of `Model` or `Interface` must
+        be given. Developers may pass an existing interface to speed
+        up repeated simulations.
+    stochastic : bool, default False
+        If True, run a stochastic simulation with the Gillespie
+        algorithm. If False, run a deterministic simulation with
+        `scipy.integrate.odeint`.
+    delay : bool, optional
+        If True, use a delay simulator. If False or None (default),
+        delay is not simulated.
+    safe : bool, default False
+        If True, use a `SafeModelCSimInterface`, which issues
+        warnings on ill-conditioned situations (e.g. a negative
+        reaction propensity), instead of the normal
+        `ModelCSimInterface`. Ignored if `Interface` is given
+        directly.
+    volume : bool or float or Volume, default False
+        If True, a default `Volume` (initial volume 1.0) is used. If
+        a positive number, a `Volume` with that initial value is
+        used. If a `Volume` instance, it is used directly. If False,
+        no volume is simulated. See the lineage module for more on
+        volume-aware simulation.
+    return_dataframe : bool, default True
+        If True, return a `pandas.DataFrame`. If False, return the
+        raw bioscrape simulation result object.
+    **keywords
+        Additional keyword arguments forwarded to
+        `DeterministicSimulator.py_simulate` (i.e. to
+        `scipy.integrate.odeint`) for deterministic simulations.
+
+    Returns
+    -------
+    pandas.DataFrame or SSAResult
+        The simulation results as a DataFrame if `return_dataframe`
+        is True, otherwise a bioscrape simulation result object
+        (`SSAResult` or one of its subclasses, depending on `delay`
+        and `volume`).
     """
-    User interface function to simulate a Bioscrape Model. 
-    Args:
-        timepoints (np.ndarray): An array that contains the times for the simulation run.
-        Model (bioscrape.types.Model): The bioscrape Model object to run.
-        Interface (bioscrape.simulator.CSimInterface): Specifies particular model simulation interface to use.
-                                                       Default: None, to create the interface automatically.
-                                                       Developers may use this to pass existing interfaces to speed up simulations.
-        stochastic (bool): If `True`, a stochastic simulation using the Gillespie stochastic simulation algorithm is run.
-                           If `False` (default), a deterministic simulation using python scipy.integrate.odeint is run.
-        delay (bool): If `True`, a delay simulator is initialized. 
-                      If `False` or None (default), delay simulator is not initialized.
-        safe (bool): If `True`, a safe model model simulation interface is initialized.
-                     A safe model simulator issues warnings when ill-conditioned situations occur in simulation 
-                     (for example, a negative propensity of a reaction)
-                     If `False` (default), normal model simulation interface is used.
-        volume (bool): If `True`, a volume is initialized for the simulation (relevant for lineage simulations)
-                       If `False` (default), volume is not used in simulations.
-                       Refer to the lineage module for more information.
-        return_dataframe (bool): If `True` (default), a Pandas dataframe with the simulation results is returned.
-                                 If `False`, a bioscrape simulation result object is returned.
-    Returns:
-        pandas.DataFrame with the simulation results if return_dataframe is set to `True`
-        or a bioscrape simulation result object is returned if it is set to `False`.
-    """
-    
+
 
     #Check model and interface
     if Model is None and Interface is None:

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -1822,12 +1822,12 @@ cdef class GeneralVolumeSplitter(VolumeSplitter):
         ----------
         options : dict of str to list of str
             Maps a partitioning mode to the species names using it.
-            ``'perfect'`` splits a species as evenly as possible
-            (+/- 0.5, keeping round numbers); ``'binomial'`` splits
-            it binomially; ``'duplicate'`` gives each daughter the
+            'perfect' splits a species as evenly as possible
+            (+/- 0.5, keeping round numbers); 'binomial' splits
+            it binomially; 'duplicate' gives each daughter the
             same count as the parent. Species not listed under
-            ``'perfect'`` or ``'duplicate'`` default to
-            ``'binomial'``.
+            'perfect' or 'duplicate' default to
+            'binomial'.
         m : Model
             The model used to look up species indices.
         """

--- a/bioscrape/simulator.pyx
+++ b/bioscrape/simulator.pyx
@@ -1809,8 +1809,7 @@ cdef class PerfectBinomialVolumeSplitter(VolumeSplitter):
 
 cdef class GeneralVolumeSplitter(VolumeSplitter):
     """
-    A volume splitting class that splits the cell into two cells and can split species
-    binomially, perfectly, or by duplication.
+    Splits species binomially, perfectly, or by duplication.
     """
     def __init__(self):
         self.partition_noise = 0

--- a/bioscrape/types.pxd
+++ b/bioscrape/types.pxd
@@ -2,6 +2,10 @@
 # cython: cdivision=True
 # cython: wraparound=False
 
+# NOTE: class/method docstrings live in types.pyx, not here. If both
+# files define a docstring for the same class/method, the .pyx one
+# silently wins with no warning at compile time.
+
 import numpy as np
 cimport numpy as np
 from vector cimport vector
@@ -28,11 +32,6 @@ ctypedef enum PropensityType:
     mass_action = 8
 
 cdef class Propensity:
-    """
-    Class for defining a propensity. Must contain a propensity type as well as two functions.
-    get_propensity returns a propensity given a state vector, parameter vector
-    get_volume_propensity is the same but also requires a volume
-    """
     cdef PropensityType propensity_type
 
     cdef double get_propensity(self, double* state, double* params, double time)
@@ -42,12 +41,6 @@ cdef class Propensity:
 
 
 cdef class ConstitutivePropensity(Propensity):
-    """
-    A propensity class for constitutive propensities. (k)
-
-    Attributes:
-        rate_index (unsigned): the parameter index containing the rate k.
-    """
     # variables
     cdef unsigned rate_index
     # constructor
@@ -58,14 +51,6 @@ cdef class ConstitutivePropensity(Propensity):
     cdef double get_stochastic_volume_propensity(self, double *state, double *params, double volume, double time)
 
 cdef class UnimolecularPropensity(Propensity):
-    """
-    A propensity class for a unimolecular propensity (k*x)
-
-    Attributes:
-        rate_index (unsigned): the parameter index containing the rate k
-        species_index (unsigned): the species index containing the species x
-    """
-
 
     # variables
     cdef unsigned rate_index
@@ -79,14 +64,6 @@ cdef class UnimolecularPropensity(Propensity):
 
 
 cdef class BimolecularPropensity(Propensity):
-    """
-    A propensity class for a bimolecular propensity (k*x1*x2)
-
-    Attributes:
-        rate_index (unsigned): the parameter index containing the rate k
-        s1_index (unsigned): the species index containing the species x1
-        s2_index (unsigned): the species index containing the species x2
-    """
 
     # variables
     cdef unsigned rate_index
@@ -100,15 +77,6 @@ cdef class BimolecularPropensity(Propensity):
     cdef double get_stochastic_volume_propensity(self, double *state, double *params, double volume, double time)
 
 cdef class PositiveHillPropensity(Propensity):
-    """
-    A propensity class for an activating Hill function (   rate * (x1/K)**n / (1 + (x1/K)**n )   )
-
-    Attributes:
-        K_index (unsigned): parameter index of Hill constant K
-        rate_index (unsigned): parameter index for rate value
-        n_index (unsigned): parameter index for cooperativity value
-        s1_index (unsigned): species index for x1
-    """
     # variables
     cdef unsigned K_index
     cdef unsigned rate_index
@@ -121,18 +89,6 @@ cdef class PositiveHillPropensity(Propensity):
     cdef double get_stochastic_volume_propensity(self, double *state, double *params, double volume, double time)
 
 cdef class PositiveProportionalHillPropensity(Propensity):
-    """
-    A propensity class for an activating Hill function proportional to another second species
-     (   rate * d * (x1/K)**n / (1 + (x1/K)**n )   )
-
-    Attributes:
-        K_index (unsigned): parameter index of Hill constant K
-        rate_index (unsigned): parameter index for rate value
-        n_index (unsigned): parameter index for cooperativity value
-        s1_index (unsigned): species index for x1
-        d_index (unsigned): species index for d
-    """
-
 
     # variables
     cdef unsigned K_index
@@ -147,15 +103,6 @@ cdef class PositiveProportionalHillPropensity(Propensity):
     cdef double get_stochastic_volume_propensity(self, double *state, double *params, double volume, double time)
 
 cdef class NegativeHillPropensity(Propensity):
-    """
-    A propensity class for a repressing Hill function (   rate * 1 / (1 + (x1/K)**n )   )
-
-    Attributes:
-        K_index (unsigned): parameter index of Hill constant K
-        rate_index (unsigned): parameter index for rate value
-        n_index (unsigned): parameter index for cooperativity value
-        s1_index (unsigned): species index for x1
-    """
 
     # variables
     cdef unsigned K_index
@@ -169,17 +116,6 @@ cdef class NegativeHillPropensity(Propensity):
     cdef double get_stochastic_volume_propensity(self, double *state, double *params, double volume, double time)
 
 cdef class NegativeProportionalHillPropensity(Propensity):
-    """
-    A propensity class for a repressing Hill function proportional to another second species
-     (   rate * d * 1 / (1 + (x1/K)**n )   )
-
-    Attributes:
-        K_index (unsigned): parameter index of Hill constant K
-        rate_index (unsigned): parameter index for rate value
-        n_index (unsigned): parameter index for cooperativity value
-        s1_index (unsigned): species index for x1
-        d_index (unsigned): species index for d
-    """
 
     # variables
     cdef unsigned K_index
@@ -332,16 +268,6 @@ ctypedef enum DelayType:
 
 
 cdef class Delay:
-    """
-    A delay class for different delay types. Must be overridden by subclasses.
-
-    Contains one function get_delay that returns a delay as a function of the state and parameters.
-
-    Attributes:
-        delay_type (DelayType): the type of delay
-        delay_params (dictionary): parameters for the delay distribution
-
-    """
     # delay type
     cdef DelayType delay_type
 
@@ -349,19 +275,10 @@ cdef class Delay:
     cdef double get_delay(self, double* state, double* params)
 
 cdef class NoDelay(Delay):
-    """
-    A delay class for representing no delay. Will always return a delay of 0.0
-    """
 
     cdef double get_delay(self, double* state, double* params)
 
 cdef class FixedDelay(Delay):
-    """
-    A delay class for representing a fixed delay.
-
-    Attributes:
-        delay_index (unsigned): parameter index containing the fixed delay value.
-    """
 
     cdef unsigned delay_index
 
@@ -369,13 +286,6 @@ cdef class FixedDelay(Delay):
 
 
 cdef class GaussianDelay(Delay):
-    """
-    A delay class for representing a Gaussian distributed delay with specified mean and std.
-
-    Attributes:
-        mean_index (unsigned): parameter index containing the mean delay
-        std_index (unsigned): parameter index containing the standard deviation of the delay.
-    """
 
     cdef unsigned mean_index
     cdef unsigned std_index
@@ -384,17 +294,6 @@ cdef class GaussianDelay(Delay):
     cdef double get_delay(self, double* state, double* params)
 
 cdef class GammaDelay(Delay):
-    """
-    A delay class for representing a gamma distributed delay with specified k and theta, where
-    it is *like* k independent exponential variables with mean theta
-
-    Mean is k*theta
-    Variance is k*theta^2
-
-    Attributes:
-        k_index (unsigned): parameter index containing the k value
-        theta_index (unsigned): parameter index containing the theta value
-    """
     cdef unsigned k_index
     cdef unsigned theta_index
 
@@ -405,10 +304,6 @@ cdef class GammaDelay(Delay):
 #################################################                     ################################################
 
 cdef class Rule:
-    """
-    A class for doing rules that must be done either at the beginning of a simulation or repeatedly at each step of
-    the simulation.
-    """
     cdef double frequency_flag #-1 if the rule always repeats, -2 if the rule repeats every dt, otherwise the rule runs at time t == frequency flag.
 
     cdef void rule_operation(self, double *state, double *params, double time, double dt)
@@ -418,9 +313,6 @@ cdef class Rule:
 
 
 cdef class AdditiveAssignmentRule(Rule):
-    """
-    A class for assigning a species to a sum of a bunch of other species.
-    """
     cdef vector[int] species_source_indices
     cdef unsigned dest_index
 
@@ -428,9 +320,6 @@ cdef class AdditiveAssignmentRule(Rule):
     cdef void rule_volume_operation(self, double *state, double *params, double volume, double time, double dt)
 
 cdef class GeneralAssignmentRule(Rule):
-    """
-    A class for assigning a species to a product of a bunch of other species.
-    """
     cdef Term rhs
     cdef unsigned dest_index
     cdef int param_flag # 1 if the assigned thing is a parameter, 0 if it's a species
@@ -440,9 +329,6 @@ cdef class GeneralAssignmentRule(Rule):
     cdef void rule_volume_operation(self, double *state, double *params, double volume, double time, double dt)
 
 cdef class GeneralODERule(Rule):
-    """
-    A class for rules that implement Euler's method every dt. These rules are of the form dest = dest + f(state, params, time)*dt
-    """
     cdef Term rhs
     cdef unsigned dest_index
     cdef int param_flag # 1 if the assigned thing is a parameter, 0 if it's a species
@@ -457,15 +343,6 @@ cdef class GeneralODERule(Rule):
 #################################################                     ################################################
 
 cdef class Volume:
-    """
-    A volume class for different volume update types. Must be overridden by subclasses implementing volume models.
-
-
-    Attributes:
-        current_volume (double): the current volume of the cell. (should be positive)
-
-    Subclasses must implement get_volume_step, initialize, cell_divided
-    """
 
     cdef double current_volume
     cdef double get_volume_step(self, double *state, double *params, double time, double volume, double dt)
@@ -490,21 +367,6 @@ cdef class Volume:
 
 
 cdef class StochasticTimeThresholdVolume(Volume):
-    """
-    A volume class for a cell that grows at a deterministic exponential rate and divides after a random normally
-    distributed time.
-
-
-    The relevant parameters for this model are the average division volume of the cell, the cell growth rate, and the
-    specified noise in the division time.
-
-    Attributes:
-        division_time (double): the time at which the cell will divide.
-        average_division_volume (double): the average volume at which to divide.
-        division_noise (double):  << 1, the noise in the division time.
-        cell_cycle_time (double): the average cell cycle time for these cells.
-        growth_rate (double): the volume growth rate g (dV/dt = g*V)
-    """
     cdef double division_time
     cdef double average_division_volume
     cdef double division_noise
@@ -518,16 +380,6 @@ cdef class StochasticTimeThresholdVolume(Volume):
 
 
 cdef class StateDependentVolume(Volume):
-    """
-    A volume class for a cell where growth rate depends on state and the division volume is chosen randomly
-    ahead of time with some randomness.
-
-    Attributes:
-        division_volume (double): the volume at which the cell will divide.
-        average_division_volume (double): the average volume at which to divide.
-        division_noise (double):  << 1, the noise in the division time (c.o.v.)
-        growth_rate (Term): the growth rate evaluated based on the state
-    """
     cdef double division_volume
     cdef double average_division_volume
     cdef double division_noise
@@ -545,26 +397,6 @@ cdef class StateDependentVolume(Volume):
 
 
 cdef class Model:
-    """
-    A class for keeping track of a chemical reaction model with delays. Does not support volumes, those are supplied
-    externally.
-
-    Attributes:
-        _next_species_index (unsigned): used internally for indexing
-        _next_params_index (unsigned): used internally for indexing
-        c_propensities (void *): vector of pointers to the model propensity objects. Must cast back to Propensity type
-        c_delays (void *): vector of pointers to model delay objects. Must cast back to Delay type
-        propensities (list): List of propensity objects. same contents as c_propensities but slower access
-        delays (list): List of delay objects. Same contents as c_delays but slower access
-        species2index (dict:str -> int): maps species names to index in species state vector.
-        params2index (dict:str -> int): maps parameter names to index in parameter vector.
-        species_values (np.ndarray): array of the initial species values
-        params_values (np.ndarray): array of the parameter values
-        update_array (np.ndarray): 2-D array containing stoichiometric matrix num_species x num_reactions
-        delay_update_array (np.ndarray): 2-D array containing delay stoich matrix (i.e. updates that occur after delay)
-
-
-    """
     ############################################################################
     # DEVELOPER WARNING 
     # 
@@ -632,16 +464,6 @@ cdef class Model:
 #################################################                     ################################################
 
 cdef class Schnitz:
-    """
-    A class for representing the data acquired from a single cell trajectory.
-
-    Attributes:
-        data (np.ndarray): A 2-D array containing one column for each measured output, 1 row for each timepoint
-        time (np.ndarray): A 1-D array containing the time points
-        volume (np.ndarray): A 1-D array with the volume at each time point
-        parent (Schnitz): The Schnitz for the parent of this cell (if it exists, None if not)
-        daughter1, daughter2 (Schnitz): The Schnitz's for the daughters of this cell (if they exist, None if not)
-    """
     cdef np.ndarray data
     cdef np.ndarray time
     cdef np.ndarray volume
@@ -676,13 +498,6 @@ cdef class Schnitz:
 
 
 cdef class Lineage:
-    """
-    A class for keeping track of cell lineages consisting of many Schnitz's
-
-    Attributes:
-        schnitzes (list): A list of all the Schnitz's in the lineage.
-        c_schnitzes (vector[void*]): A vector containing void pointers to all the Schnitz's in the lineage
-    """
 
     cdef list schnitzes
     cdef vector[void*] c_schnitzes

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -169,7 +169,7 @@ cdef class Propensity:
 
 cdef class ConstitutivePropensity(Propensity):
     r"""
-    Constant (zeroth-order) propensity: $\rho = k$.
+    Constant (zeroth-order) propensity, rate = k.
 
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with zero reactant
@@ -180,7 +180,7 @@ cdef class ConstitutivePropensity(Propensity):
     Attributes
     ----------
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     """
     # constructor
     def __init__(self):
@@ -212,20 +212,20 @@ cdef class ConstitutivePropensity(Propensity):
 
 cdef class UnimolecularPropensity(Propensity):
     r"""
-    First-order propensity: $\rho = k x$.
+    First-order propensity, rate = k*x.
 
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with one reactant
     species; not normally constructed directly. Recognized
     `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the reactant species name $x$).
+    `species` (the reactant species name x).
 
     Attributes
     ----------
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     species_index : int
-        The species index of $x$.
+        The species index of x.
     """
     # constructor
     def __init__(self):
@@ -260,7 +260,7 @@ cdef class UnimolecularPropensity(Propensity):
 
 cdef class BimolecularPropensity(Propensity):
     r"""
-    Second-order propensity: $\rho = k x_1 x_2$.
+    Second-order propensity, rate = k*x1*x2.
 
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with two reactant
@@ -269,16 +269,16 @@ cdef class BimolecularPropensity(Propensity):
     `species` (the two reactant species names, e.g. 'A*B'). If the
     two species are the same (e.g. 'A*A'), the stochastic
     propensity accounts for the discrete copy-number effect of a
-    species reacting with itself: $\rho = k x_1 (x_1 - 1)$.
+    species reacting with itself: rate = k*x1*(x1 - 1).
 
     Attributes
     ----------
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     s1_index : int
-        The species index of $x_1$.
+        The species index of x1.
     s2_index : int
-        The species index of $x_2$.
+        The species index of x2.
     """
     # constructor
     def __init__(self):
@@ -327,24 +327,23 @@ cdef class BimolecularPropensity(Propensity):
 
 cdef class PositiveHillPropensity(Propensity):
     r"""
-    Activating Hill propensity:
-    $\rho = k (x_1/K)^n / (1 + (x_1/K)^n)$.
+    Activating Hill propensity, rate = k*(x1/K)^n / (1 + (x1/K)^n).
 
     Constructed via `~Model.create_reaction` with
     ``propensity_type='hillpositive'``. Recognized
     `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), and `s1` (the species $x_1$).
+    `n` (cooperativity/Hill coefficient), and `s1` (the species x1).
 
     Attributes
     ----------
     K_index : int
-        The parameter index of the Hill constant $K$.
+        The parameter index of the Hill constant K.
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     n_index : int
-        The parameter index of the cooperativity $n$.
+        The parameter index of the cooperativity n.
     s1_index : int
-        The species index of $x_1$.
+        The species index of x1.
     """
     # constructor
     def __init__(self):
@@ -393,28 +392,28 @@ cdef class PositiveHillPropensity(Propensity):
 
 cdef class PositiveProportionalHillPropensity(Propensity):
     r"""
-    Activating Hill propensity proportional to a second species:
-    $\rho = k d (x_1/K)^n / (1 + (x_1/K)^n)$.
+    Activating Hill propensity proportional to a second species.
 
-    Constructed via `~Model.create_reaction` with
+    rate = k*d*(x1/K)^n / (1 + (x1/K)^n). Constructed via
+    `~Model.create_reaction` with
     ``propensity_type='proportionalhillpositive'``. Recognized
     `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), `s1` (the species $x_1$),
-    and `d` (the proportional species $d$, e.g. an enzyme or
+    `n` (cooperativity/Hill coefficient), `s1` (the species x1),
+    and `d` (the proportional species d, e.g. an enzyme or
     polymerase whose abundance scales the rate).
 
     Attributes
     ----------
     K_index : int
-        The parameter index of the Hill constant $K$.
+        The parameter index of the Hill constant K.
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     n_index : int
-        The parameter index of the cooperativity $n$.
+        The parameter index of the cooperativity n.
     s1_index : int
-        The species index of $x_1$.
+        The species index of x1.
     d_index : int
-        The species index of $d$.
+        The species index of d.
     """
     # constructor
     def __init__(self):
@@ -469,24 +468,24 @@ cdef class PositiveProportionalHillPropensity(Propensity):
 
 cdef class NegativeHillPropensity(Propensity):
     r"""
-    Repressing Hill propensity: $\rho = k / (1 + (x_1/K)^n)$.
+    Repressing Hill propensity, rate = k / (1 + (x1/K)^n).
 
     Constructed via `~Model.create_reaction` with
     ``propensity_type='hillnegative'``. Recognized
     `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
     `n` (cooperativity/Hill coefficient), and `s1` (the repressor
-    species $x_1$).
+    species x1).
 
     Attributes
     ----------
     K_index : int
-        The parameter index of the Hill constant $K$.
+        The parameter index of the Hill constant K.
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     n_index : int
-        The parameter index of the cooperativity $n$.
+        The parameter index of the cooperativity n.
     s1_index : int
-        The species index of $x_1$.
+        The species index of x1.
     """
     # constructor
     def __init__(self):
@@ -530,27 +529,27 @@ cdef class NegativeHillPropensity(Propensity):
 
 cdef class NegativeProportionalHillPropensity(Propensity):
     r"""
-    Repressing Hill propensity proportional to a second species:
-    $\rho = k d / (1 + (x_1/K)^n)$.
+    Repressing Hill propensity proportional to a second species.
 
-    Constructed via `~Model.create_reaction` with
+    rate = k*d / (1 + (x1/K)^n). Constructed via
+    `~Model.create_reaction` with
     ``propensity_type='proportionalhillnegative'``. Recognized
     `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
     `n` (cooperativity/Hill coefficient), `s1` (the repressor species
-    $x_1$), and `d` (the proportional species $d$).
+    x1), and `d` (the proportional species d).
 
     Attributes
     ----------
     K_index : int
-        The parameter index of the Hill constant $K$.
+        The parameter index of the Hill constant K.
     rate_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     n_index : int
-        The parameter index of the cooperativity $n$.
+        The parameter index of the cooperativity n.
     s1_index : int
-        The species index of $x_1$.
+        The species index of x1.
     d_index : int
-        The species index of $d$.
+        The species index of d.
     """
     # constructor
     def __init__(self):
@@ -649,8 +648,7 @@ cdef class NegativeProportionalHillPropensity(Propensity):
 
 cdef class MassActionPropensity(Propensity):
     r"""
-    General mass-action propensity: $\rho = k \prod_i x_i$ over the
-    reactant species.
+    General mass-action propensity, rate = k times the reactant product.
 
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with three or more
@@ -663,7 +661,7 @@ cdef class MassActionPropensity(Propensity):
     reaction where species `A` appears with multiplicity 2). The
     deterministic propensity multiplies each distinct species once;
     the stochastic propensity additionally accounts for repeated
-    species via falling-factorial terms (e.g. $x(x-1)$ for a species
+    species via falling-factorial terms (e.g. x*(x-1) for a species
     with multiplicity 2), matching combinatorial reaction kinetics.
 
     Attributes
@@ -673,7 +671,7 @@ cdef class MassActionPropensity(Propensity):
     sp_counts : list of int
         The multiplicity of each species in `sp_inds`.
     k_index : int
-        The parameter index of the rate $k$.
+        The parameter index of the rate k.
     """
     def __init__(self):
         self.propensity_type = PropensityType.mass_action
@@ -1064,7 +1062,7 @@ cdef class PowerTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class ExpTerm(Term):
-    """An expression node computing $e$ raised to its argument term."""
+    """An expression node computing the natural exponential of its argument term."""
     cdef void set_arg(self, Term arg):
         self.arg = arg
 
@@ -1511,11 +1509,11 @@ cdef class GaussianDelay(Delay):
 
 cdef class GammaDelay(Delay):
     r"""
-    A gamma-distributed delay with shape $k$ and scale $\theta$.
+    A gamma-distributed delay with shape k and scale theta.
 
-    Resampled at each reaction firing; equivalent to the sum of $k$
-    independent exponential random variables with mean $\theta$; has
-    mean $k\theta$ and variance $k\theta^2$.
+    Resampled at each reaction firing; equivalent to the sum of k
+    independent exponential random variables with mean theta; has
+    mean k*theta and variance k*theta^2.
 
     Constructed via `~Model.create_reaction` with
     ``delay_type='gamma'``. Recognized `delay_param_dict` keys: `k`
@@ -1524,9 +1522,9 @@ cdef class GammaDelay(Delay):
     Attributes
     ----------
     k_index : int
-        The parameter index of the shape $k$.
+        The parameter index of the shape k.
     theta_index : int
-        The parameter index of the scale $\theta$.
+        The parameter index of the scale theta.
     """
 
     def __init__(self):
@@ -2052,28 +2050,28 @@ cdef class StochasticTimeThresholdVolume(Volume):
     A cell that grows exponentially and divides at a random time.
 
     Growth is deterministic; the division time is sampled once, at
-    `initialize`, as
-    $\mathcal{N}(1, \text{noise}) \times T$, where $T$ is the
-    deterministic time remaining to reach `average_division_volume`
-    at the current growth rate.
+    `initialize`, as T times a normally-distributed random variable
+    with mean 1 and standard deviation `division_noise`, where T is
+    the deterministic time remaining to reach
+    `average_division_volume` at the current growth rate.
 
     Parameters
     ----------
     cell_cycle_time : float
         The average cell cycle time; sets the growth rate to
-        $\log(2) / \text{cell\_cycle\_time}$.
+        log(2) / cell_cycle_time.
     average_division_volume : float
         The average volume at which the cell divides.
     division_noise : float
-        The relative noise (coefficient of variation, $\ll 1$) in the
-        division time.
+        The relative noise (coefficient of variation, much less than 1)
+        in the division time.
 
     Attributes
     ----------
     division_time : float
         The (pre-sampled) time at which the cell will divide.
     growth_rate : float
-        The volume growth rate $g$, where $dV/dt = gV$.
+        The volume growth rate g, where dV/dt = g*V.
     """
     def __init__(self, double cell_cycle_time, double average_division_volume, double division_noise):
         self.cell_cycle_time = cell_cycle_time
@@ -2147,8 +2145,7 @@ cdef class StochasticTimeThresholdVolume(Volume):
 
 cdef class StateDependentVolume(Volume):
     r"""
-    A cell whose growth rate depends on the current state, with a
-    randomly chosen division volume.
+    A cell with a state-dependent growth rate and a random division volume.
 
     Must be configured via `setup` after construction (`__init__`
     takes no arguments).
@@ -2160,8 +2157,8 @@ cdef class StateDependentVolume(Volume):
     average_division_volume : float
         The average volume at which to divide.
     division_noise : float
-        The relative noise (coefficient of variation, $\ll 1$) in the
-        division volume.
+        The relative noise (coefficient of variation, much less than 1)
+        in the division volume.
     growth_rate : Term
         The growth rate expression, evaluated based on the state.
     """

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -158,6 +158,14 @@ cdef class Propensity:
         fields : dict
             The propensity's field dictionary (as passed to
             `initialize`).
+        **keywords
+            Ignored here; `~Model` calls every propensity's
+            `get_species_and_parameters` uniformly with
+            `species2index`/`params2index` (dicts mapping species/
+            parameter names to their state/parameter vector index),
+            for the benefit of subclasses (e.g. `GeneralPropensity`)
+            that need to resolve a symbolic expression instead of
+            just reading names out of `fields`.
 
         Returns
         -------
@@ -1433,6 +1441,13 @@ cdef class Delay:
         ----------
         fields : dict
             The delay's field dictionary (as passed to `initialize`).
+        **keywords
+            Ignored here; `~Model` calls every delay's
+            `get_species_and_parameters` uniformly with
+            `species2index`/`params2index` (dicts mapping species/
+            parameter names to their state/parameter vector index),
+            not used by any built-in `Delay` subclass but available
+            to custom subclasses that need them.
 
         Returns
         -------
@@ -2473,9 +2488,6 @@ cdef class Model:
         for rule_object in self.repeat_rules:
             self.c_repeat_rules.push_back(<void*> rule_object)
 
-    def py_initialize(self):
-        self._initialize()
-
     def __eq__(self, Model other):
         if other is None or not isinstance(other, Model):
             return False
@@ -2984,7 +2996,7 @@ cdef class Model:
         Fills in all local variables (propensities, delays, update
         arrays) and maps species/parameters to indices.
 
-        .. deprecated::
+        .. deprecated:: 1.0.2.2
             Bioscrape XML is being replaced by SBML and will no
             longer be supported in a future version of the software.
 

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -266,8 +266,8 @@ cdef class BimolecularPropensity(Propensity):
     ``propensity_type='massaction'`` reactions with two reactant
     species; not normally constructed directly. Recognized
     `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the two reactant species names, e.g. ``'A*B'``). If the
-    two species are the same (e.g. ``'A*A'``), the stochastic
+    `species` (the two reactant species names, e.g. 'A*B'). If the
+    two species are the same (e.g. 'A*A'), the stochastic
     propensity accounts for the discrete copy-number effect of a
     species reacting with itself: $\rho = k x_1 (x_1 - 1)$.
 
@@ -659,7 +659,7 @@ cdef class MassActionPropensity(Propensity):
     instead for zero, one, and two reactant species respectively);
     not normally constructed directly. Recognized
     `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the reactant species names, e.g. ``'A*A*B'`` for a
+    `species` (the reactant species names, e.g. 'A*A*B' for a
     reaction where species `A` appears with multiplicity 2). The
     deterministic propensity multiplies each distinct species once;
     the stochastic propensity additionally accounts for repeated
@@ -1280,7 +1280,7 @@ cdef class GeneralPropensity(Propensity):
     Constructed via `~Model.create_reaction` with
     ``propensity_type='general'``. Recognized
     `propensity_param_dict` key: `rate`, a string expression in
-    species and parameter names (e.g. ``'k*A*B'``), parsed into a
+    species and parameter names (e.g. 'k*A*B'), parsed into a
     `Term` expression tree via `parse_expression`.
     """
 
@@ -1709,7 +1709,7 @@ cdef class AdditiveAssignmentRule(Rule):
 
     Constructed via `~Model.create_rule` with
     ``rule_type='additive'``. `rule_attributes['equation']` must be of
-    the form ``'dest = src1 + src2 + ...'``, naming the destination
+    the form 'dest = src1 + src2 + ...', naming the destination
     species and the source species to sum (no other expression forms
     are supported; see `GeneralAssignmentRule` for arbitrary
     expressions).
@@ -1752,7 +1752,7 @@ cdef class GeneralAssignmentRule(Rule):
 
     Constructed via `~Model.create_rule` with
     ``rule_type='assignment'``. `rule_attributes['equation']` must be
-    of the form ``'dest = expression'``, where `expression` is parsed
+    of the form 'dest = expression', where `expression` is parsed
     (via `parse_expression`) into a `Term` tree and re-evaluated each
     time the rule fires; `dest` may be a species or a parameter name.
     """
@@ -2557,9 +2557,9 @@ cdef class Model:
         Parameters
         ----------
         propensity_type : str
-            One of ``'massaction'``, ``'hillpositive'``,
-            ``'proportionalhillpositive'``, ``'hillnegative'``,
-            ``'proportionalhillnegative'``, or ``'general'``.
+            One of 'massaction', 'hillpositive',
+            'proportionalhillpositive', 'hillnegative',
+            'proportionalhillnegative', or 'general'.
         propensity_param_dict : dict
             Parameters for the given propensity type. Numeric values
             are automatically converted to dummy parameters.
@@ -2657,14 +2657,14 @@ cdef class Model:
         products : list of str
             Product species names.
         propensity_type : str
-            One of ``'massaction'``, ``'hillpositive'``,
-            ``'proportionalhillpositive'``, ``'hillnegative'``,
-            ``'proportionalhillnegative'``, or ``'general'``.
+            One of 'massaction', 'hillpositive',
+            'proportionalhillpositive', 'hillnegative',
+            'proportionalhillnegative', or 'general'.
         propensity_param_dict : dict
             Parameters for the given propensity type.
         delay_type : str, optional
-            One of ``'none'``, ``'fixed'``, ``'gaussian'``, or
-            ``'gamma'``. Defaults to no delay.
+            One of 'none', 'fixed', 'gaussian', or
+            'gamma'. Defaults to no delay.
         delay_reactants : list of str, optional
             Reactant species names for the delayed part of the
             reaction.
@@ -2797,13 +2797,13 @@ cdef class Model:
         Parameters
         ----------
         rule_type : str
-            One of ``'additive'`` (`AdditiveAssignmentRule`),
-            ``'assignment'`` (`GeneralAssignmentRule`), or ``'ode'``
+            One of 'additive' (`AdditiveAssignmentRule`),
+            'assignment' (`GeneralAssignmentRule`), or 'ode'
             (`GeneralODERule`, always run at every timestep
             regardless of `rule_frequency`).
         rule_attributes : dict
             Rule parameters/attributes. For additive/assignment
-            rules, the only attribute used is ``'equation'``.
+            rules, the only attribute used is 'equation'.
         rule_frequency : str, default "repeated"
             When the rule fires; see `Rule.set_frequency_flag` for
             the supported values.
@@ -3489,7 +3489,7 @@ cdef class Model:
         -------
         list of str
             One string per reaction, formatted as
-            ``"reactants ->[propensity] products"``.
+            'reactants ->[propensity] products'.
         """
         reaction_strings = []
 

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -28,19 +28,40 @@ cdef float float_epsilon = numeric_limits[float].epsilon()
 
 
 cdef class Propensity:
+    """
+    Base class for reaction propensity (rate law) functions.
+
+    Subclasses implement `get_propensity` and `get_volume_propensity`
+    (both `cdef`, called from Python via `py_get_propensity` and
+    `py_get_volume_propensity`). By default, volume propensities fall
+    back to the non-volume propensity, and stochastic propensities
+    fall back to the deterministic ones; a subclass overrides either
+    where the behavior actually differs (e.g.
+    `BimolecularPropensity` and `MassActionPropensity`, whose
+    stochastic propensities account for discrete copy-number effects
+    when a species reacts with itself).
+    """
     def __init__(self):
-        """
-        Set the propensity type enum variable.
-        """
         self.propensity_type = PropensityType.unset
 
     def py_get_propensity(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                           double time = 0.0):
         """
-        Calculate propensity in pure python given a state and parameter vector.
-        :param state: (np.ndarray) state vector of doubles
-        :param params: (np.ndarray) parameter vector of doubles.
-        :return: (double) computed propensity, should be non-negative
+        Compute the propensity at a given state and parameter vector.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+        time : float, optional
+            The current time (default 0.0).
+
+        Returns
+        -------
+        float
+            The computed propensity (non-negative).
         """
         return self.get_propensity(<double*> state.data, <double*> params.data, time)
 
@@ -82,32 +103,85 @@ cdef class Propensity:
 
     def py_get_volume_propensity(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                                  double volume, double time = 0.0):
+        """
+        Compute the volume-dependent propensity.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+        volume : float
+            The cell volume.
+        time : float, optional
+            The current time (default 0.0).
+
+        Returns
+        -------
+        float
+            The computed propensity (non-negative).
+        """
         return self.get_volume_propensity(<double*> state.data, <double*> params.data, volume, time)
 
 
 
     def initialize(self, dict param_dictionary, dict species_indices, dict parameter_indices):
         """
-        Initializes the parameters and species to look at the right indices in the state
-        :param dictionary: (dict:str--> str) the fields for the propensity 'k','s1' etc map to the actual parameter
-                                             and species names
-        :param species_indices: (dict:str-->int) map species names to entry in species vector
-        :param parameter_indices: (dict:str-->int) map param names to entry in param vector
-        :return: nothing
+        Bind this propensity's field names to state/parameter indices.
+
+        Called once by `~bioscrape.types.Model` when the model is
+        initialized; not normally called directly. The recognized keys
+        in `param_dictionary` (e.g. 'k', 's1', 'K', 'n') depend on the
+        propensity subclass -- see each subclass's docstring.
+
+        Parameters
+        ----------
+        param_dictionary : dict
+            Maps field names (e.g. 'k', 's1') to species or parameter
+            names.
+        species_indices : dict
+            Maps species names to their index in the state vector.
+        parameter_indices : dict
+            Maps parameter names to their index in the parameter
+            vector.
         """
         pass
 
     def get_species_and_parameters(self, dict fields, **keywords):
         """
-        get which fields are species and which are parameters
-        :param dict(str-->str) dictionary containing the propensity to process.
-        :return: (list(string), list(string)) First entry is the names of species, second entry is the names of parameters
+        The species and parameter names referenced by this propensity.
+
+        Parameters
+        ----------
+        fields : dict
+            The propensity's field dictionary (as passed to
+            `initialize`).
+
+        Returns
+        -------
+        tuple of list of str
+            `(species_names, parameter_names)`.
         """
         return (None,None)
 
 
 
 cdef class ConstitutivePropensity(Propensity):
+    r"""
+    Constant (zeroth-order) propensity: $\rho = k$.
+
+    Selected automatically by `~Model.create_reaction` for
+    ``propensity_type='massaction'`` reactions with zero reactant
+    species (the fastest of the specialized mass-action propensities);
+    not normally constructed directly. Recognized
+    `propensity_param_dict` key: `k` (the rate parameter name).
+
+    Attributes
+    ----------
+    rate_index : int
+        The parameter index of the rate $k$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.constitutive
@@ -137,6 +211,22 @@ cdef class ConstitutivePropensity(Propensity):
 
 
 cdef class UnimolecularPropensity(Propensity):
+    r"""
+    First-order propensity: $\rho = k x$.
+
+    Selected automatically by `~Model.create_reaction` for
+    ``propensity_type='massaction'`` reactions with one reactant
+    species; not normally constructed directly. Recognized
+    `propensity_param_dict` keys: `k` (the rate parameter name) and
+    `species` (the reactant species name $x$).
+
+    Attributes
+    ----------
+    rate_index : int
+        The parameter index of the rate $k$.
+    species_index : int
+        The species index of $x$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.unimolecular
@@ -169,7 +259,27 @@ cdef class UnimolecularPropensity(Propensity):
 
 
 cdef class BimolecularPropensity(Propensity):
+    r"""
+    Second-order propensity: $\rho = k x_1 x_2$.
 
+    Selected automatically by `~Model.create_reaction` for
+    ``propensity_type='massaction'`` reactions with two reactant
+    species; not normally constructed directly. Recognized
+    `propensity_param_dict` keys: `k` (the rate parameter name) and
+    `species` (the two reactant species names, e.g. ``'A*B'``). If the
+    two species are the same (e.g. ``'A*A'``), the stochastic
+    propensity accounts for the discrete copy-number effect of a
+    species reacting with itself: $\rho = k x_1 (x_1 - 1)$.
+
+    Attributes
+    ----------
+    rate_index : int
+        The parameter index of the rate $k$.
+    s1_index : int
+        The species index of $x_1$.
+    s2_index : int
+        The species index of $x_2$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.bimolecular
@@ -216,7 +326,26 @@ cdef class BimolecularPropensity(Propensity):
 
 
 cdef class PositiveHillPropensity(Propensity):
+    r"""
+    Activating Hill propensity:
+    $\rho = k (x_1/K)^n / (1 + (x_1/K)^n)$.
 
+    Constructed via `~Model.create_reaction` with
+    ``propensity_type='hillpositive'``. Recognized
+    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
+    `n` (cooperativity/Hill coefficient), and `s1` (the species $x_1$).
+
+    Attributes
+    ----------
+    K_index : int
+        The parameter index of the Hill constant $K$.
+    rate_index : int
+        The parameter index of the rate $k$.
+    n_index : int
+        The parameter index of the cooperativity $n$.
+    s1_index : int
+        The species index of $x_1$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.hill_positive
@@ -263,7 +392,30 @@ cdef class PositiveHillPropensity(Propensity):
 
 
 cdef class PositiveProportionalHillPropensity(Propensity):
+    r"""
+    Activating Hill propensity proportional to a second species:
+    $\rho = k d (x_1/K)^n / (1 + (x_1/K)^n)$.
 
+    Constructed via `~Model.create_reaction` with
+    ``propensity_type='proportionalhillpositive'``. Recognized
+    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
+    `n` (cooperativity/Hill coefficient), `s1` (the species $x_1$),
+    and `d` (the proportional species $d$, e.g. an enzyme or
+    polymerase whose abundance scales the rate).
+
+    Attributes
+    ----------
+    K_index : int
+        The parameter index of the Hill constant $K$.
+    rate_index : int
+        The parameter index of the rate $k$.
+    n_index : int
+        The parameter index of the cooperativity $n$.
+    s1_index : int
+        The species index of $x_1$.
+    d_index : int
+        The species index of $d$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.proportional_hill_positive
@@ -316,7 +468,26 @@ cdef class PositiveProportionalHillPropensity(Propensity):
                 "})^{p" + str(self.n_index) + "})"
 
 cdef class NegativeHillPropensity(Propensity):
+    r"""
+    Repressing Hill propensity: $\rho = k / (1 + (x_1/K)^n)$.
 
+    Constructed via `~Model.create_reaction` with
+    ``propensity_type='hillnegative'``. Recognized
+    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
+    `n` (cooperativity/Hill coefficient), and `s1` (the repressor
+    species $x_1$).
+
+    Attributes
+    ----------
+    K_index : int
+        The parameter index of the Hill constant $K$.
+    rate_index : int
+        The parameter index of the rate $k$.
+    n_index : int
+        The parameter index of the cooperativity $n$.
+    s1_index : int
+        The species index of $x_1$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.hill_negative
@@ -358,7 +529,29 @@ cdef class NegativeHillPropensity(Propensity):
 
 
 cdef class NegativeProportionalHillPropensity(Propensity):
+    r"""
+    Repressing Hill propensity proportional to a second species:
+    $\rho = k d / (1 + (x_1/K)^n)$.
 
+    Constructed via `~Model.create_reaction` with
+    ``propensity_type='proportionalhillnegative'``. Recognized
+    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
+    `n` (cooperativity/Hill coefficient), `s1` (the repressor species
+    $x_1$), and `d` (the proportional species $d$).
+
+    Attributes
+    ----------
+    K_index : int
+        The parameter index of the Hill constant $K$.
+    rate_index : int
+        The parameter index of the rate $k$.
+    n_index : int
+        The parameter index of the cooperativity $n$.
+    s1_index : int
+        The species index of $x_1$.
+    d_index : int
+        The species index of $d$.
+    """
     # constructor
     def __init__(self):
         self.propensity_type = PropensityType.proportional_hill_negative
@@ -404,6 +597,19 @@ cdef class NegativeProportionalHillPropensity(Propensity):
         return ([ fields['s1'], fields['d'] ],[ fields['K'],fields['n'],fields['k'] ])
 
     def set_species(self, species, species_indices):
+        """
+        Bind the `s1` and `d` species names to state-vector indices.
+
+        An alternative to `~Propensity.initialize` for setting just
+        the species fields.
+
+        Parameters
+        ----------
+        species : dict
+            Maps 's1' and/or 'd' to species names.
+        species_indices : dict
+            Maps species names to their index in the state vector.
+        """
         for key in species:
             if key == 's1':
                 self.s1_index = species_indices[species['s1']]
@@ -412,6 +618,20 @@ cdef class NegativeProportionalHillPropensity(Propensity):
             else:
                 logging.info('Warning! Useless field for NegativeProportionalHillPropensity '+str(key))
     def set_parameters(self, parameters, parameter_indices):
+        """
+        Bind the `K`, `n`, and `k` parameter names to indices.
+
+        An alternative to `~Propensity.initialize` for setting just
+        the parameter fields.
+
+        Parameters
+        ----------
+        parameters : dict
+            Maps 'K', 'n', and/or 'k' to parameter names.
+        parameter_indices : dict
+            Maps parameter names to their index in the parameter
+            vector.
+        """
         for key in parameters:
             if key == 'K':
                 self.K_index = parameter_indices[parameters[key]]
@@ -428,6 +648,33 @@ cdef class NegativeProportionalHillPropensity(Propensity):
 
 
 cdef class MassActionPropensity(Propensity):
+    r"""
+    General mass-action propensity: $\rho = k \prod_i x_i$ over the
+    reactant species.
+
+    Selected automatically by `~Model.create_reaction` for
+    ``propensity_type='massaction'`` reactions with three or more
+    reactant species (`ConstitutivePropensity`,
+    `UnimolecularPropensity`, and `BimolecularPropensity` are used
+    instead for zero, one, and two reactant species respectively);
+    not normally constructed directly. Recognized
+    `propensity_param_dict` keys: `k` (the rate parameter name) and
+    `species` (the reactant species names, e.g. ``'A*A*B'`` for a
+    reaction where species `A` appears with multiplicity 2). The
+    deterministic propensity multiplies each distinct species once;
+    the stochastic propensity additionally accounts for repeated
+    species via falling-factorial terms (e.g. $x(x-1)$ for a species
+    with multiplicity 2), matching combinatorial reaction kinetics.
+
+    Attributes
+    ----------
+    sp_inds : list of int
+        The species index of each distinct reactant species.
+    sp_counts : list of int
+        The multiplicity of each species in `sp_inds`.
+    k_index : int
+        The parameter index of the rate $k$.
+    """
     def __init__(self):
         self.propensity_type = PropensityType.mass_action
 
@@ -502,6 +749,15 @@ cdef class MassActionPropensity(Propensity):
 
 @cython.auto_pickle(True)
 cdef class Term:
+    """
+    Base class for nodes in a parsed symbolic expression tree.
+
+    Used internally by `GeneralPropensity` and
+    `~bioscrape.types.GeneralODERule` to evaluate arbitrary symbolic rate/rule
+    expressions (parsed from a string); not normally constructed directly.
+    Subclasses implement `evaluate` and `volume_evaluate` (both `cdef`),
+    called from Python via `py_evaluate`/`py_volume_evaluate`.
+    """
     cdef double evaluate(self, double *species, double *params, double time):
         raise SyntaxError('Cannot make Term base object')
 
@@ -510,16 +766,60 @@ cdef class Term:
 
 
     def py_evaluate(self, np.ndarray species, np.ndarray params, double time=0.0):
+        """
+        Evaluate this expression node.
+
+        Parameters
+        ----------
+        species : numpy.ndarray
+            The state (species) vector.
+        params : numpy.ndarray
+            The parameter vector.
+        time : float, optional
+            The current time (default 0.0).
+
+        Returns
+        -------
+        float
+            The value of this expression node.
+        """
         return self.evaluate(<double*> species.data, <double*> params.data, time)
 
     def py_volume_evaluate(self, np.ndarray species, np.ndarray params,
                            double vol, double time=0.0):
+        """
+        Evaluate this expression node with a cell volume.
+
+        Parameters
+        ----------
+        species : numpy.ndarray
+            The state (species) vector.
+        params : numpy.ndarray
+            The parameter vector.
+        vol : float
+            The cell volume.
+        time : float, optional
+            The current time (default 0.0).
+
+        Returns
+        -------
+        float
+            The value of this expression node.
+        """
         return self.volume_evaluate(<double*> species.data, <double*> params.data,
                                     vol, time)
 
 # Base building blocks
 @cython.auto_pickle(True)
 cdef class ConstantTerm(Term):
+    """
+    A constant-valued expression node.
+
+    Parameters
+    ----------
+    val : float
+        The constant value.
+    """
 
     def __init__(self, double val):
         self.value = val
@@ -534,6 +834,14 @@ cdef class ConstantTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class SpeciesTerm(Term):
+    """
+    An expression node referencing a species value by index.
+
+    Parameters
+    ----------
+    ind : int
+        The species index.
+    """
     def __init__(self, unsigned ind):
         self.index = ind
 
@@ -547,6 +855,14 @@ cdef class SpeciesTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class ParameterTerm(Term):
+    """
+    An expression node referencing a parameter value by index.
+
+    Parameters
+    ----------
+    ind : int
+        The parameter index.
+    """
     def __init__(self, unsigned ind):
         self.index = ind
 
@@ -559,6 +875,12 @@ cdef class ParameterTerm(Term):
         return " {p" + str(self.index) + "} "
 
 cdef class VolumeTerm(Term):
+    """
+    An expression node representing the cell volume.
+
+    Evaluates to 1.0 via `evaluate` (no volume given) and to the cell
+    volume via `volume_evaluate`.
+    """
     cdef double evaluate(self, double *species, double *params, double time):
         return 1.0
     cdef double volume_evaluate(self, double *species, double *params, double vol, double time):
@@ -586,6 +908,13 @@ def restore_binary_term(state, ClassName):
     return new_term
 
 cdef class BinaryTerm(Term):
+    """
+    Base class for expression nodes that combine a list of child terms.
+
+    Subclasses (`SumTerm`, `ProductTerm`, `MaxTerm`, `MinTerm`)
+    implement `evaluate`/`volume_evaluate` by reducing over the child
+    terms added via `py_add_term`.
+    """
     def __init__(self):
         self.terms_list = []
 
@@ -597,9 +926,18 @@ cdef class BinaryTerm(Term):
         self.terms_list.append(trm)
 
     def py_add_term(self, Term trm):
+        """
+        Append a child expression node.
+
+        Parameters
+        ----------
+        trm : Term
+            The child term to add.
+        """
         self.add_term(trm)
 
 cdef class SumTerm(BinaryTerm):
+    """An expression node summing its child terms."""
     cdef double evaluate(self, double *species, double *params, double time):
         cdef double ans = 0.0
         cdef unsigned i
@@ -622,6 +960,7 @@ cdef class SumTerm(BinaryTerm):
         return string_rep
 
 cdef class ProductTerm(BinaryTerm):
+    """An expression node multiplying its child terms."""
     cdef double evaluate(self, double *species, double *params, double time):
         cdef double ans = 1.0
         cdef unsigned i
@@ -644,6 +983,7 @@ cdef class ProductTerm(BinaryTerm):
         return string_rep
 
 cdef class MaxTerm(BinaryTerm):
+    """An expression node taking the maximum of its child terms."""
     cdef double evaluate(self, double *species, double *params, double time):
         cdef double ans = (<Term>(self.terms[0])).evaluate(species, params,time)
         cdef unsigned i
@@ -673,6 +1013,7 @@ cdef class MaxTerm(BinaryTerm):
         return string_rep
 
 cdef class MinTerm(BinaryTerm):
+    """An expression node taking the minimum of its child terms."""
     cdef double evaluate(self, double *species, double *params, double time):
         cdef double ans = (<Term>(self.terms[0])).evaluate(species, params,time)
         cdef unsigned i
@@ -704,6 +1045,7 @@ cdef class MinTerm(BinaryTerm):
 
 @cython.auto_pickle(True)
 cdef class PowerTerm(Term):
+    """An expression node raising a base term to an exponent term."""
     cdef void set_base(self, Term base):
         self.base = base
     cdef void set_exponent(self, Term exponent):
@@ -722,6 +1064,7 @@ cdef class PowerTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class ExpTerm(Term):
+    """An expression node computing $e$ raised to its argument term."""
     cdef void set_arg(self, Term arg):
         self.arg = arg
 
@@ -736,6 +1079,7 @@ cdef class ExpTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class LogTerm(Term):
+    """An expression node computing the natural log of its argument."""
     cdef void set_arg(self, Term arg):
         self.arg = arg
 
@@ -750,6 +1094,7 @@ cdef class LogTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class StepTerm(Term):
+    """A Heaviside step node: 1 if its argument is >= 0, else 0."""
     cdef void set_arg(self, Term arg):
         self.arg = arg
 
@@ -768,6 +1113,7 @@ cdef class StepTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class AbsTerm(Term):
+    """An expression node computing the absolute value of its argument."""
     cdef void set_arg(self, Term arg):
         self.arg = arg
 
@@ -782,6 +1128,7 @@ cdef class AbsTerm(Term):
 
 @cython.auto_pickle(True)
 cdef class TimeTerm(Term):
+    """An expression node representing the current simulation time."""
     cdef double evaluate(self, double *species, double *params, double time):
         return time
 
@@ -927,6 +1274,15 @@ def parse_expression(instring, species2index, params2index):
 
 
 cdef class GeneralPropensity(Propensity):
+    """
+    Propensity defined by an arbitrary symbolic rate expression.
+
+    Constructed via `~Model.create_reaction` with
+    ``propensity_type='general'``. Recognized
+    `propensity_param_dict` key: `rate`, a string expression in
+    species and parameter names (e.g. ``'k*A*B'``), parsed into a
+    `Term` expression tree via `parse_expression`.
+    """
 
     cdef double get_propensity(self, double* state, double* params, double time):
         return self.term.evaluate(state,params,time)
@@ -937,14 +1293,35 @@ cdef class GeneralPropensity(Propensity):
         self.propensity_type = PropensityType.general
 
     def initialize(self, dict dictionary, dict species2index, dict params2index):
+        """
+        Parse the `rate` field into an expression tree.
+
+        Parameters
+        ----------
+        dictionary : dict
+            Must contain a `rate` key with the symbolic rate
+            expression string.
+        species2index : dict
+            Maps species names to their index in the state vector.
+        params2index : dict
+            Maps parameter names to their index in the parameter
+            vector.
+        """
         instring = dictionary['rate']
         self.term = parse_expression(instring, species2index, params2index)
 
     def get_species_and_parameters(self, dict fields, dict species2index, dict params2index):
-        instring = fields['rate'].strip()
-        return sympy_species_and_parameters(instring, species2index, params2index)
+        return sympy_species_and_parameters(fields['rate'].strip(), species2index, params2index)
 
     def py_get_term(self):
+        """
+        The parsed expression tree for this propensity's rate.
+
+        Returns
+        -------
+        Term
+            The root node of the parsed `rate` expression.
+        """
         return self.term
 
     def __str__(self):
@@ -956,22 +1333,44 @@ cdef class GeneralPropensity(Propensity):
 #################################################                     ################################################
 
 cdef class Delay:
+    """
+    Base class for stochastic reaction delay distributions.
+
+    Contains one function, `get_delay` (`cdef`, called from Python via
+    `py_get_delay`), that returns a delay as a function of the state
+    and parameter vectors; must be overridden by subclasses. Attached
+    to a reaction via `~Model.create_reaction`'s `delay_type` argument
+    (e.g. 'fixed', 'gaussian', 'gamma') rather than constructed
+    directly.
+
+    Attributes
+    ----------
+    delay_type : DelayType
+        The type of delay.
+    """
     def __init__(self):
-        """
-        Set the delay_type attribute to the appropriate enum value.
-        """
         self.delay_type = DelayType.unset_delay
 
     def py_get_delay(self, np.ndarray[np.double_t,ndim=1] state,
                      np.ndarray[np.double_t,ndim=1] params):
         """
-        Return the delay given the state and parameter vector
-        :param state: (np.ndarray) the state vector
-        :param params: (np.ndarray) the parameters vector
-        :return: (double) the computed delay
+        Sample/compute the delay at a given state and parameter vector.
 
-        This function should NOT be overridden by subclases. It is just a Python
-        wrapped of the cython delay function.
+        This function should NOT be overridden by subclasses. It is
+        just a Python wrapper of the `cdef` `get_delay` function,
+        which subclasses should override instead.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+
+        Returns
+        -------
+        float
+            The computed delay.
         """
         return self.get_delay(<double*> state.data, <double*> params.data)
 
@@ -992,32 +1391,46 @@ cdef class Delay:
 
     def initialize(self, dict param_dictionary, dict species_indices,
                    dict parameter_indices):
-
         """
-        Initializes the parameters and species to look at the right indices in
-            the state
-        :param dictionary: (dict:str--> str) the fields for the propensity 'k',
-                                            's1' etc map to the actual parameter
-                                             and species names
-        :param species_indices: (dict:str-->int) map species names to entry in
-                                species vector
-        :param parameter_indices: (dict:str-->int) map param names to entry in
-                                  param vector
-        :return: nothing
+        Bind this delay's field names to state/parameter indices.
+
+        Called once by `~bioscrape.types.Model` when the model is
+        initialized; not normally called directly. The recognized
+        keys in `param_dictionary` (e.g. 'delay', 'mean', 'std', 'k',
+        'theta') depend on the delay subclass -- see each subclass's
+        docstring.
+
+        Parameters
+        ----------
+        param_dictionary : dict
+            Maps field names to species or parameter names.
+        species_indices : dict
+            Maps species names to their index in the state vector.
+        parameter_indices : dict
+            Maps parameter names to their index in the parameter
+            vector.
         """
         pass
 
     def get_species_and_parameters(self, dict fields, **keywords):
         """
-        get which fields are species and which are parameters
-        :return: (list(string), list(string)) First entry is the fields that are
-                                            species, second entry is the fields
-                                            that are parameters
+        The species and parameter names referenced by this delay.
+
+        Parameters
+        ----------
+        fields : dict
+            The delay's field dictionary (as passed to `initialize`).
+
+        Returns
+        -------
+        tuple of list of str
+            `(species_names, parameter_names)`.
         """
         return [],[]
 
 
 cdef class NoDelay(Delay):
+    """A delay of 0.0 (no delay); the default when no delay is specified."""
     def __init__(self):
         self.delay_type = DelayType.none
 
@@ -1025,6 +1438,18 @@ cdef class NoDelay(Delay):
         return 0.0
 
 cdef class FixedDelay(Delay):
+    """
+    A fixed (deterministic) delay.
+
+    Constructed via `~Model.create_reaction` with
+    ``delay_type='fixed'``. Recognized `delay_param_dict` key: `delay`
+    (the name of the parameter giving the fixed delay value).
+
+    Attributes
+    ----------
+    delay_index : int
+        The parameter index of the delay value.
+    """
 
     def __init__(self):
         self.delay_type = DelayType.fixed
@@ -1045,6 +1470,21 @@ cdef class FixedDelay(Delay):
         return [], [fields['delay']]
 
 cdef class GaussianDelay(Delay):
+    """
+    A Gaussian-distributed delay, resampled at each reaction firing.
+
+    Constructed via `~Model.create_reaction` with
+    ``delay_type='gaussian'``. Recognized `delay_param_dict` keys:
+    `mean` and `std` (parameter names giving the distribution's mean
+    and standard deviation).
+
+    Attributes
+    ----------
+    mean_index : int
+        The parameter index of the mean.
+    std_index : int
+        The parameter index of the standard deviation.
+    """
 
     def __init__(self):
         self.delay_type = DelayType.gaussian
@@ -1070,6 +1510,24 @@ cdef class GaussianDelay(Delay):
 
 
 cdef class GammaDelay(Delay):
+    r"""
+    A gamma-distributed delay with shape $k$ and scale $\theta$.
+
+    Resampled at each reaction firing; equivalent to the sum of $k$
+    independent exponential random variables with mean $\theta$; has
+    mean $k\theta$ and variance $k\theta^2$.
+
+    Constructed via `~Model.create_reaction` with
+    ``delay_type='gamma'``. Recognized `delay_param_dict` keys: `k`
+    and `theta` (parameter names giving the shape and scale).
+
+    Attributes
+    ----------
+    k_index : int
+        The parameter index of the shape $k$.
+    theta_index : int
+        The parameter index of the scale $\theta$.
+    """
 
     def __init__(self):
         self.delay_type = DelayType.gamma
@@ -1097,8 +1555,15 @@ cdef class GammaDelay(Delay):
 
 cdef class Rule:
     """
-    A class for doing rules that must be done either at the beginning of a simulation or repeatedly at each step of
-    the simulation.
+    Base class for model rules.
+
+    Rules apply updates outside the normal reaction network, either
+    once at the start of a simulation or repeatedly during it.
+    Subclasses implement `rule_operation` and `rule_volume_operation`
+    (both `cdef`); `execute_rule`/`execute_volume_rule` (also `cdef`,
+    called from Python via `py_execute_rule`/`py_execute_volume_rule`)
+    apply them according to the rule's frequency, set via
+    `set_frequency_flag`.
     """
     cdef void rule_operation(self, double *state, double *params, double time, double dt):
         raise NotImplementedError('Creating base Rule class. This should be subclassed.')
@@ -1116,32 +1581,112 @@ cdef class Rule:
 
     def py_execute_rule(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                         double time = 0.0, double dt = .01, rule_step = True):
+        """
+        Apply this rule if it is due to fire.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector, updated in place if the rule fires.
+        params : numpy.ndarray
+            The parameter vector, updated in place if the rule targets
+            a parameter.
+        time : float, optional
+            The current time (default 0.0).
+        dt : float, optional
+            The simulation time step, used by 'dt'-frequency rules
+            (default 0.01).
+        rule_step : bool, optional
+            Whether this call corresponds to a full simulation time
+            step; relevant for 'dt'-frequency rules (default True).
+        """
         self.execute_rule(<double*> state.data, <double*> params.data,time, dt, rule_step)
 
     def py_execute_volume_rule(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                                double volume, double time=0.0, double dt = .01, rule_step = True):
+        """
+        Apply this rule (with a cell volume) if it is due to fire.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector, updated in place if the rule fires.
+        params : numpy.ndarray
+            The parameter vector, updated in place if the rule targets
+            a parameter.
+        volume : float
+            The cell volume.
+        time : float, optional
+            The current time (default 0.0).
+        dt : float, optional
+            The simulation time step, used by 'dt'-frequency rules
+            (default 0.01).
+        rule_step : bool, optional
+            Whether this call corresponds to a full simulation time
+            step; relevant for 'dt'-frequency rules (default True).
+        """
         self.execute_volume_rule(<double*> state.data, <double*> params.data, volume,time, dt, rule_step)
 
     def initialize(self, dict dictionary, dict species_indices, dict parameter_indices, rule_frequency = "repeat"):
         """
-        Initializes the parameters and species to look at the right indices in the state
-        :param dictionary: (dict:str--> str) the fields for the propensity 'k','s1' etc map to the actual parameter
-                                             and species names
-        :param species_indices: (dict:str-->int) map species names to entry in species vector
-        :param parameter_indices: (dict:str-->int) map param names to entry in param vector
-        :return: nothing
+        Bind this rule's field names to state/parameter indices.
+
+        Called once by `~bioscrape.types.Model` when the model is
+        initialized; not normally called directly. The recognized
+        keys in `dictionary` depend on the rule subclass -- see each
+        subclass's docstring.
+
+        Parameters
+        ----------
+        dictionary : dict
+            Maps field names to species/parameter names or
+            expressions.
+        species_indices : dict
+            Maps species names to their index in the state vector.
+        parameter_indices : dict
+            Maps parameter names to their index in the parameter
+            vector.
+        rule_frequency : str or float, optional
+            How often the rule fires; see `set_frequency_flag`
+            (default 'repeat').
         """
         pass
 
     def get_species_and_parameters(self, dict fields, **keywords):
         """
-        get which fields are species and which are parameters
-        :param dict(str-->str) dictionary containing the propensity to process.
-        :return: (list(string), list(string)) First entry is the names of species, second entry is the names of parameters
+        The species and parameter names referenced by this rule.
+
+        Parameters
+        ----------
+        fields : dict
+            The rule's field dictionary (as passed to `initialize`).
+
+        Returns
+        -------
+        tuple of list of str
+            `(species_names, parameter_names)`.
         """
         return (None,None)
 
     def set_frequency_flag(self, rule_frequency):
+        """
+        Set when this rule fires.
+
+        Parameters
+        ----------
+        rule_frequency : str or float
+            'start' fires the rule once, at simulation start. 'repeat'
+            (or 'repeated') fires it at every reaction/timepoint. 'dt'
+            fires it once per simulation time step (used by
+            `GeneralODERule`). A non-negative number fires it only at
+            that specific time.
+
+        Raises
+        ------
+        ValueError
+            If `rule_frequency` is not one of the recognized strings
+            and cannot be interpreted as a non-negative float.
+        """
         if rule_frequency == "start":
             self.frequency_flag = 0.0
 
@@ -1160,7 +1705,14 @@ cdef class Rule:
 
 cdef class AdditiveAssignmentRule(Rule):
     """
-    A class for assigning a species to a sum of a bunch of other species.
+    Assigns a species to the sum of a list of other species.
+
+    Constructed via `~Model.create_rule` with
+    ``rule_type='additive'``. `rule_attributes['equation']` must be of
+    the form ``'dest = src1 + src2 + ...'``, naming the destination
+    species and the source species to sum (no other expression forms
+    are supported; see `GeneralAssignmentRule` for arbitrary
+    expressions).
     """
 
     cdef void rule_operation(self, double *state, double *params, double time, double dt):
@@ -1196,8 +1748,13 @@ cdef class AdditiveAssignmentRule(Rule):
 
 cdef class GeneralAssignmentRule(Rule):
     """
-    A class for doing rules that must be done either at the beginning of a simulation or repeatedly at each step of
-    the simulation.
+    Assigns a species or parameter to an arbitrary expression's value.
+
+    Constructed via `~Model.create_rule` with
+    ``rule_type='assignment'``. `rule_attributes['equation']` must be
+    of the form ``'dest = expression'``, where `expression` is parsed
+    (via `parse_expression`) into a `Term` tree and re-evaluated each
+    time the rule fires; `dest` may be a species or a parameter name.
     """
     cdef void rule_operation(self, double *state, double *params, double time, double dt):
         if self.param_flag > 0:
@@ -1247,7 +1804,15 @@ cdef class GeneralAssignmentRule(Rule):
 
 cdef class GeneralODERule(Rule):
     """
-    A class for rules that implement Euler's method every dt. These rules are of the form dest = dest + f(state, params, time)*dt
+    Numerically integrates a target via Euler's method.
+
+    Constructed via `~Model.create_rule` with ``rule_type='ode'``
+    (frequency is forced to fire once per simulation time step).
+    `rule_attributes` must contain `target` (the destination species
+    or parameter name) and `equation` (a symbolic expression `f`,
+    parsed via `parse_expression`); each firing adds
+    ``f(state, params, time) * dt`` to the target's current value (a
+    first-order Euler step).
     """
     cdef void rule_operation(self, double *state, double *params, double time, double dt):
         if self.param_flag > 0:
@@ -1301,6 +1866,21 @@ cdef class GeneralODERule(Rule):
 #################################################                     ################################################
 
 cdef class Volume:
+    """
+    Base class for cell volume models.
+
+    Used by volume-aware simulators
+    (`~bioscrape.simulator.VolumeSSASimulator`,
+    `~bioscrape.simulator.DelayVolumeSSASimulator`) to track a cell's
+    volume and determine when it divides. Subclasses implement
+    `get_volume_step`, `initialize`, `cell_divided`, and `copy` (all
+    `cdef`).
+
+    Attributes
+    ----------
+    current_volume : float
+        The current volume of the cell (should be positive).
+    """
     cdef double get_volume_step(self, double *state, double *params, double time, double volume, double dt):
         """
         Return the volume change in a time step of dt ending at time t given the state, parameters, and volume at t-d
@@ -1325,13 +1905,38 @@ cdef class Volume:
 
     def py_copy(self):
         """
-        Copy function for deep copying
-        :return: a deep copy of the volume object
+        A deep copy of this volume object.
+
+        Returns
+        -------
+        Volume
+            The copy.
         """
         return self.copy()
 
     def py_get_volume_step(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                            double time, double volume, double dt):
+        """
+        Compute the volume change over a time step.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+        time : float
+            The ending time after the volume step has occurred.
+        volume : float
+            The volume before the volume step occurs.
+        dt : float
+            The width of the time step.
+
+        Returns
+        -------
+        float
+            The change in cell volume from `time - dt` to `time`.
+        """
         return self.get_volume_step(<double*> state.data, <double*> params.data, time, volume, dt)
 
 
@@ -1355,6 +1960,24 @@ cdef class Volume:
 
     def py_initialize(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
                       double time, double volume):
+        """
+        Initialize the volume at the start of a simulation.
+
+        Required to handle non-memoryless properties (e.g. a
+        pre-sampled division time); called once before simulation
+        begins.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+        time : float
+            The initial time.
+        volume : float
+            The initial volume.
+        """
         self.initialize(<double*> state.data, <double*> params.data, time, volume)
 
     cdef unsigned cell_divided(self, double *state, double *params, double time, double volume, double dt):
@@ -1376,26 +1999,83 @@ cdef class Volume:
 
     def py_cell_divided(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params, double time,
                         double volume, double dt):
+        """
+        Whether the cell divided during a time step.
+
+        Parameters
+        ----------
+        state : numpy.ndarray
+            The state vector.
+        params : numpy.ndarray
+            The parameter vector.
+        time : float
+            The ending time of the time step.
+        volume : float
+            The volume after the time step occurred.
+        dt : float
+            The width of the time step.
+
+        Returns
+        -------
+        bool
+            True if the cell divided in `[time - dt, time]`.
+        """
         return self.cell_divided(<double*> state.data, <double*> params.data, time, volume, dt)
 
 
     def py_set_volume(self, double v):
+        """
+        Set the current volume.
+
+        Parameters
+        ----------
+        v : float
+            The volume to set (should be positive).
+        """
         self.set_volume(v)
     def py_get_volume(self):
+        """
+        The current volume.
+
+        Returns
+        -------
+        float
+            The current volume.
+        """
         return self.get_volume()
 
 
 
 
 cdef class StochasticTimeThresholdVolume(Volume):
-    def __init__(self, double cell_cycle_time, double average_division_volume, double division_noise):
-        """
-        Initialize the class with the cell cycle time, average division volume, and noise parameter.
+    r"""
+    A cell that grows exponentially and divides at a random time.
 
-        :param cell_cycle_time: (double) cell cycle time on average
-        :param average_division_volume: (double) average volume at division
-        :param division_noise: (double) noise in the cell cycle time as a relative c.o.v.
-        """
+    Growth is deterministic; the division time is sampled once, at
+    `initialize`, as
+    $\mathcal{N}(1, \text{noise}) \times T$, where $T$ is the
+    deterministic time remaining to reach `average_division_volume`
+    at the current growth rate.
+
+    Parameters
+    ----------
+    cell_cycle_time : float
+        The average cell cycle time; sets the growth rate to
+        $\log(2) / \text{cell\_cycle\_time}$.
+    average_division_volume : float
+        The average volume at which the cell divides.
+    division_noise : float
+        The relative noise (coefficient of variation, $\ll 1$) in the
+        division time.
+
+    Attributes
+    ----------
+    division_time : float
+        The (pre-sampled) time at which the cell will divide.
+    growth_rate : float
+        The volume growth rate $g$, where $dV/dt = gV$.
+    """
+    def __init__(self, double cell_cycle_time, double average_division_volume, double division_noise):
         self.cell_cycle_time = cell_cycle_time
         self.average_division_volume = average_division_volume
         self.division_noise = division_noise
@@ -1466,21 +2146,48 @@ cdef class StochasticTimeThresholdVolume(Volume):
         return 0
 
 cdef class StateDependentVolume(Volume):
-    """
-    A volume class for a cell where growth rate depends on state and the division volume is chosen randomly
-    ahead of time with some randomness.
+    r"""
+    A cell whose growth rate depends on the current state, with a
+    randomly chosen division volume.
 
-    Attributes:
-        division_volume (double): the volume at which the cell will divide.
-        average_division_volume (double): the average volume at which to divide.
-        division_noise (double):  << 1, the noise in the division time (c.o.v.)
-        growth_rate (Term): the growth rate evaluated based on the state
+    Must be configured via `setup` after construction (`__init__`
+    takes no arguments).
+
+    Attributes
+    ----------
+    division_volume : float
+        The volume at which the cell will divide.
+    average_division_volume : float
+        The average volume at which to divide.
+    division_noise : float
+        The relative noise (coefficient of variation, $\ll 1$) in the
+        division volume.
+    growth_rate : Term
+        The growth rate expression, evaluated based on the state.
     """
 
     def __init__(self):
         pass
 
     def setup(self, double average_division_volume, double division_noise, growth_rate, Model m):
+        """
+        Configure the growth rate and division volume distribution.
+
+        Parameters
+        ----------
+        average_division_volume : float
+            The average volume at which to divide.
+        division_noise : float
+            The relative noise (coefficient of variation) in the
+            division volume.
+        growth_rate : str
+            A symbolic expression for the growth rate as a function of
+            model species/parameters, parsed via
+            `~Model.parse_general_expression`.
+        m : Model
+            The model providing the species/parameter context used to
+            parse `growth_rate`.
+        """
         self.average_division_volume = average_division_volume
         self.division_noise = division_noise
         self.growth_rate = m.parse_general_expression(growth_rate)
@@ -1518,39 +2225,85 @@ cdef class StateDependentVolume(Volume):
 ##############################                     #############################
 
 cdef class Model:
-    def __init__(self, sbml_filename = None, filename = None, species = [], reactions = [], 
-                 parameters = [], rules = [], initial_condition_dict = None, 
+    """A chemical reaction network model with optional delays.
+
+    A `Model` can be built from an SBML file, a (deprecated) bioscrape
+    XML file, or programmatically from the `species`, `reactions`,
+    `parameters`, and `rules` arguments. These can be combined, and
+    the model API (`create_reaction`, `create_rule`, `set_parameter`,
+    etc.) can be used to extend the model further after construction.
+    See the bioscrape wiki for full API documentation:
+    https://github.com/biocircuits/bioscrape/wiki
+
+    Volumes are not represented internally; they must be supplied
+    externally, e.g. by a `Volume` object driving a simulator.
+
+    Parameters
+    ----------
+    sbml_filename : str, optional
+        Path to an SBML file to import. Cannot be combined with any
+        other constructor argument except `input_printout` and
+        `**kwargs`; import the SBML model first, then edit it with
+        the API. If neither `sbml_filename` nor `filename` is given,
+        no file is loaded and the model is built entirely from
+        `species`, `reactions`, `parameters`, and `rules`.
+    filename : str, optional
+        Path to a (deprecated) bioscrape XML file to import. Prefer
+        `sbml_filename` for new models.
+    species : list of str, default []
+        Species names to add to the model.
+    reactions : list of tuple, default []
+        Reaction tuples, each either
+        `(reactants, products, propensity_type, propensity_param_dict)`
+        or the 8-tuple form that also specifies a delay. See the
+        bioscrape wiki for the full reaction tuple format.
+    parameters : list of tuple or dict, default []
+        `(name, value)` pairs, or a dict, giving initial parameter
+        values.
+    rules : list of tuple, default []
+        Rule tuples, each `(rule_type, rule_attributes)` or
+        `(rule_type, rule_attributes, rule_frequency)`. See the
+        bioscrape wiki for the rule tuple format.
+    initial_condition_dict : dict, optional
+        Maps species names to initial values.
+    input_printout : bool, default False
+        If True, print verbose status messages while constructing
+        the model.
+    initialize_model : bool, default True
+        If True, validate the model and build its internal arrays
+        (see `py_initialize`) after construction.
+    **kwargs
+        Additional keyword arguments forwarded to `import_sbml` when
+        loading from `sbml_filename`.
+
+    Attributes
+    ----------
+    species2index : dict
+        Maps species names to their index in `species_values` and in
+        the model's stoichiometric matrices.
+    params2index : dict
+        Maps parameter names to their index in `params_values`.
+    species_values : numpy.ndarray
+        Current species values, indexed via `species2index`.
+    params_values : numpy.ndarray
+        Parameter values, indexed via `params2index`.
+    propensities : list of Propensity
+        Propensity object for each reaction, in the order the
+        reactions were added.
+    delays : list of Delay
+        Delay object for each reaction, in the order the reactions
+        were added.
+    update_array : numpy.ndarray
+        Stoichiometric matrix (num_species x num_reactions) for
+        changes that occur immediately.
+    delay_update_array : numpy.ndarray
+        Stoichiometric matrix (num_species x num_reactions) for
+        changes that occur after a delay.
+    """
+    def __init__(self, sbml_filename = None, filename = None, species = [], reactions = [],
+                 parameters = [], rules = [], initial_condition_dict = None,
                  input_printout = False, initialize_model = True, **kwargs):
-        """
-        Read in a model from a file using old bioscrape XML format (now deprecated), SBML format, or by 
-        specifying the model programmatically using the API.
-        Model API documentation is available on bioscrape Wiki:
-        https://github.com/biocircuits/bioscrape/wiki
-
-        Args:
-            sbml_filename (str): The SBML filename to import the model. 
-                                Note that you cannot any other arguments when importing from SBML.
-                                You can import the SBML model, then edit the model with the API.
-                                If no keyword argument is passed, then an SBML file is assumed as the input.
-            filename (str):     The (old bioscrape XML) file to read the model. Recommended way to import 
-                                a model is by importing an SBML using `sbml_filename` argument
-            species (List[str]): A list of species names, when constructing the model. 
-            reaction (List[tuple]): A list of reaction tuples. Each reaction tuple includes a list
-                                    of reactants, a list of products, a propensity string,
-                                    and the propensity dict.
-                                    Refer to the documentation on bioscrape Wiki for more information.
-            parameters (List[tuples]): A list of tuples where each tuple specifies the parameter name
-                                       and a value for the parameter.
-            rules (List[(tuples)]): A list of tuples where each tuple describe a model rule.
-            initial_condition_dict (dict): A dictionary of initial conditions where each key is a species name
-                                           and the value is the initial condition value.
-            input_printout (bool, default: False): If True, verbose print statements are printed out.
-                                                   If False, the print statements are silenced.
-            initial_model (bool, default: True): If True, the model is initialized => 
-                                                 Model arrays are created and basic validity checks are run.
-                                                 If False, the model is not initialized. 
-
-        """
+        """See class docstring."""
 
         ########################################################################
         # DEVELOPER WARNING 
@@ -1675,6 +2428,14 @@ cdef class Model:
         self.initialized = True
 
     def py_initialize(self):
+        """Validate the model and build its internal C-level arrays.
+
+        Creates the propensity/delay C-vectors and the stoichiometric
+        matrices, and checks that all parameters and species have
+        values (see `check_parameters` and `check_species`). Called
+        automatically by the constructor unless
+        `initialize_model=False` was passed.
+        """
         self._initialize()
 
     def _create_vectors(self):
@@ -1785,6 +2546,36 @@ cdef class Model:
 
 
     def create_propensity(self, propensity_type, propensity_param_dict, input_printout = False):
+        """Construct a `Propensity` object of the given type.
+
+        Automatically picks the fastest matching subclass for
+        `propensity_type='massaction'`, based on the number of
+        reactant species (`ConstitutivePropensity`,
+        `UnimolecularPropensity`, `BimolecularPropensity`, or
+        `MassActionPropensity`).
+
+        Parameters
+        ----------
+        propensity_type : str
+            One of ``'massaction'``, ``'hillpositive'``,
+            ``'proportionalhillpositive'``, ``'hillnegative'``,
+            ``'proportionalhillnegative'``, or ``'general'``.
+        propensity_param_dict : dict
+            Parameters for the given propensity type. Numeric values
+            are automatically converted to dummy parameters.
+        input_printout : bool, default False
+            If True, print the propensity type and parameters.
+
+        Returns
+        -------
+        Propensity
+            The constructed propensity object.
+
+        Raises
+        ------
+        SyntaxError
+            If `propensity_type` is not a recognized type.
+        """
         if input_printout:
             print("Creating Propensity: prop_type="+str(propensity_type)+" params="+str(propensity_param_dict))
         if 'type' in propensity_param_dict:
@@ -1850,24 +2641,41 @@ cdef class Model:
             raise SyntaxError('Propensity Type is not supported: ' + propensity_type)
 
         return prop_object
-    #A function to programatically create a reaction (and automatically add it to the model).
-    #   Supports all native propensity types and delay types.
-    #Required Inputs:
-    #   reactants (list): a list of reactant specie names (strings)
-    #   products (list): a list of product specie names (strings)
-    #   propensity_type: a string indicating the type of propensity
-    #       Supported types: "massaction", "hillpositive", "proportionalhillpositive", "hillnegative", "proportionalhillnegative", "general"
-    #   propensity_param_dict: a dictionary of parameters for the given propensity type
-    #Optional Inputs:
-    #   delay_type: a string indicating the type of delay
-    #   delay_reactants (list): a list of delay reaction reactant specie names (strings)
-    #   delay_products: a list of delay reaction products specie names (strings)
-    #   delay_param_dict: a dictionary of the parameters for the delay distribution
+
     def create_reaction(self, reactants, products, propensity_type,
                         propensity_param_dict, delay_type = None,
                         delay_reactants = None, delay_products = None,
                         delay_param_dict = None, input_printout = False):
+        """Create a reaction and add it to the model.
 
+        Supports all native propensity types and delay types.
+
+        Parameters
+        ----------
+        reactants : list of str
+            Reactant species names.
+        products : list of str
+            Product species names.
+        propensity_type : str
+            One of ``'massaction'``, ``'hillpositive'``,
+            ``'proportionalhillpositive'``, ``'hillnegative'``,
+            ``'proportionalhillnegative'``, or ``'general'``.
+        propensity_param_dict : dict
+            Parameters for the given propensity type.
+        delay_type : str, optional
+            One of ``'none'``, ``'fixed'``, ``'gaussian'``, or
+            ``'gamma'``. Defaults to no delay.
+        delay_reactants : list of str, optional
+            Reactant species names for the delayed part of the
+            reaction.
+        delay_products : list of str, optional
+            Product species names for the delayed part of the
+            reaction.
+        delay_param_dict : dict, optional
+            Parameters for the delay distribution.
+        input_printout : bool, default False
+            If True, print the reaction being created.
+        """
         if input_printout:
             print("creating reaction with:"+
                 "\n\tPropensity_type="+str(propensity_type)+" Inputs="+str(reactants)+" Outputs="+str(products)+
@@ -1983,13 +2791,30 @@ cdef class Model:
             self._next_params_index += 1
             self.params_values = np.concatenate((self.params_values, np.array([np.nan])))
 
-    #Creates a rule and adds it to the model.
-    #Inputs:
-    #   rule_type (str): The type of rule. Supported: "additive" and "assignment"
-    #   rule_attributes (dict): A dictionary of rule parameters / attributes.
-    #       NOTE: the only attributes used by additive/assignment rules are 'equation'
-    #Rule Types Supported:
     def create_rule(self, rule_type, rule_attributes, rule_frequency = "repeated", input_printout = False):
+        """Create a rule and add it to the model.
+
+        Parameters
+        ----------
+        rule_type : str
+            One of ``'additive'`` (`AdditiveAssignmentRule`),
+            ``'assignment'`` (`GeneralAssignmentRule`), or ``'ode'``
+            (`GeneralODERule`, always run at every timestep
+            regardless of `rule_frequency`).
+        rule_attributes : dict
+            Rule parameters/attributes. For additive/assignment
+            rules, the only attribute used is ``'equation'``.
+        rule_frequency : str, default "repeated"
+            When the rule fires; see `Rule.set_frequency_flag` for
+            the supported values.
+        input_printout : bool, default False
+            If True, print the rule being created.
+
+        Raises
+        ------
+        SyntaxError
+            If `rule_type` is not a recognized type.
+        """
         if input_printout:
             print("Rule Created with \n\trule_type = "+str(rule_type)+"\n\trule_attributes="+str(rule_attributes)+"\n\trule_frequency="+str(rule_frequency))
 
@@ -2020,8 +2845,19 @@ cdef class Model:
         self.rule_definitions.append((rule_type, rule_attributes, rule_frequency))
 
 
-    #Sets the value of a parameter in the model
     def set_parameter(self, param_name, param_value):
+        """Set the value of a parameter in the model.
+
+        If the parameter does not already exist in the model, it is
+        added (and a warning is logged).
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name.
+        param_value : float
+            The value to set.
+        """
         if param_name not in self.params2index:
             logging.info('Warning! parameter '+ param_name+" does not show up in any currently defined reactions or rules.")
             self._add_param(param_name)
@@ -2030,11 +2866,26 @@ cdef class Model:
         self.params_values[param_index] = param_value
 
     def create_parameter(self, param_name, param_value):
+        """Add a new parameter to the model and set its value.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name.
+        param_value : float
+            The value to set.
+        """
         self._add_param(param_name)
         self.set_parameter(param_name, param_value)
 
-    #Checks that all parameters have values
     def check_parameters(self):
+        """Check that every parameter in the model has a value.
+
+        Raises
+        ------
+        ValueError
+            If any parameter has no value (is NaN).
+        """
         error_string = "Unspecified Parameters: "
         unspecified_parameters = False
         for p in self.params2index:
@@ -2047,8 +2898,12 @@ cdef class Model:
             error_string += f" (params2index is {self.params2index}; param_values is {self.params_values})"
             raise ValueError(error_string[:-2])
 
-    #Checks that species' values are all set. Unset values default to 0 and warning is raised.
     def check_species(self):
+        """Check that every species in the model has a value.
+
+        Any species without an initial condition is defaulted to 0
+        and a warning is logged.
+        """
         uninitialized_species = False
         warning_txt = "The following species are uninitialized and their value has been defaulted to 0: "
         for s in self.species2index.keys():
@@ -2106,13 +2961,22 @@ cdef class Model:
         return self.update_array, self.delay_update_array
 
     def parse_model(self, filename, input_printout = False):
-        """
-        Parse the model from an XML file filling in all the local variables (propensities, delays, update arrays). Also
-        maps the species and parameters to indices in a species and parameters vector.
+        """Parse the model from a (deprecated) bioscrape XML file.
 
-        :param filename: (str or file) the model file. if a string, the file is opened. otherwise, it is assumed
-                         that a file handle was passed in.
-        :return: None
+        Fills in all local variables (propensities, delays, update
+        arrays) and maps species/parameters to indices.
+
+        .. deprecated::
+            Bioscrape XML is being replaced by SBML and will no
+            longer be supported in a future version of the software.
+
+        Parameters
+        ----------
+        filename : str or file
+            The model file. If a string, the file is opened;
+            otherwise it is assumed to already be a file handle.
+        input_printout : bool, default False
+            If True, print verbose status messages while parsing.
         """
         # open XML file from the filename and use BeautifulSoup to parse it
         warnings.warn("Deprecated Warning: Bioscrape XML is being replaced by SBML and will no longer be supported in a future version of the software.")
@@ -2212,54 +3076,65 @@ cdef class Model:
 
 
     def has_delays(self):
+        """Return True if any reaction in the model has a delay."""
         if self.has_delay:
             return True
         else:
             return False
 
     def get_params2index(self):
+        """Return the dict mapping parameter names to indices."""
         return self.params2index
 
     def get_species2index(self):
+        """Return the dict mapping species names to indices."""
         return self.species2index
 
     def get_species_list(self):
+        """Return species names as a list, ordered by index."""
         l = [None] * self.get_number_of_species()
         for s in self.species2index:
             l[self.species2index[s]] = s
         return l
 
     def get_species_array(self):
+        """Return the current species values as a `numpy.ndarray`."""
         return np.array(self.species_values)
 
     def get_param_list(self):
+        """Return parameter names as a list, ordered by index."""
         l = [None] * self.get_number_of_params()
         for p in self.params2index:
             l[self.params2index[p]] = p
         return l
 
     def get_params(self):
-        """
-        Get the set of parameter names.
-        :return: (dict_keys str) the parameter names
-        """
+        """Return the set of parameter names.
 
+        Returns
+        -------
+        dict_keys of str
+            The parameter names.
+        """
         return self.params2index.keys()
 
     def get_species(self):
         """
-        Get the set of species names.
+        Get the set of parameter names.
         :return: (dict_keys str) the parameter names
         """
         return self.species2index.keys()
 
     def get_number_of_params(self):
+        """Return the number of parameters in the model."""
         return len(self.params2index.keys())
 
     def get_parameter_values(self):
+        """Return the parameter values as a `numpy.ndarray`."""
         return self.params_values
 
     def get_parameter_dictionary(self):
+        """Return a dict mapping parameter names to their values."""
         param_dict = {}
         keys = self.get_params()
         values = self.get_parameter_values()
@@ -2268,17 +3143,17 @@ cdef class Model:
         return param_dict
 
     def get_species(self):
-        """
-        Get the set of species names.
-        :return: (dict_keys str) the species names
-        """
+        """Return the set of species names.
 
+        Returns
+        -------
+        dict_keys of str
+            The species names.
+        """
         return self.species2index.keys()
 
     def get_species_dictionary(self):
-        """
-        Get a dictionary {"species":value}
-        """
+        """Return a dict mapping species names to their values."""
         A = self.get_species_array()
         species_dict = {}
         for s in self.species2index:
@@ -2287,14 +3162,17 @@ cdef class Model:
         # return {(s, A[self.species2index[s]]) for s in self.species2index}
 
     def get_number_of_species(self):
+        """Return the number of species in the model."""
         return len(self.species2index.keys())
 
-
     def set_params(self, param_dict):
-        """
-        Set parameter values
-        :param param_dict: (dict:str -> double) Dictionary containing the parameters to set mapped to desired values.
-        :return: None
+        """Set parameter values.
+
+        Parameters
+        ----------
+        param_dict : dict of str to float
+            Maps parameter names to the values to set. Names not
+            already in the model trigger a warning and are ignored.
         """
         param_names = set(self.params2index.keys())
         for p in param_dict:
@@ -2305,11 +3183,13 @@ cdef class Model:
 
 
     def set_species(self, species_dict):
-        """
-        Set initial species values
+        """Set initial species values.
 
-        :param species_dict: (dict:str -> double) Dictionary containing the species to set mapped to desired values.
-        :return: None
+        Parameters
+        ----------
+        species_dict : dict of str to float
+            Maps species names to the values to set. Names not
+            already in the model trigger a warning and are ignored.
         """
         species_names = set(self.species2index.keys())
         for s in species_dict:
@@ -2327,25 +3207,27 @@ cdef class Model:
         return & self.c_repeat_rules
 
     def get_propensities(self):
-        """
-        Get the propensities list.
-
-        :return: (list) List of the propensities for each reaction.
-        """
+        """Return the list of `Propensity` objects, one per reaction."""
         return self.propensities
 
     def get_delays(self):
-        """
-        Get the delays list
-
-        :return: (list) List of the delay objects for each reaction.
-        """
+        """Return the list of `Delay` objects, one per reaction."""
         return self.delays
 
     def get_reactions(self):
+        """Return the internal list of reaction tuples.
+
+        Each entry is
+        `(propensity_object, delay_object, reaction_update_dict,
+        delay_reaction_update_dict)`.
+        """
         return self.reaction_list
 
     def get_rules(self):
+        """Return the list of rule definition tuples.
+
+        Each entry is `(rule_type, rule_attributes, rule_frequency)`.
+        """
         return self.rule_definitions
 
     cdef np.ndarray get_species_values(self):
@@ -2386,6 +3268,14 @@ cdef class Model:
         return self.update_array
 
     def py_get_update_array(self):
+        """Return the stoichiometric matrix for immediate changes.
+
+        Returns
+        -------
+        numpy.ndarray
+            A 2-D array with 1 row per species, 1 column per
+            reaction.
+        """
         return self.update_array
 
     cdef np.ndarray get_delay_update_array(self):
@@ -2396,38 +3286,111 @@ cdef class Model:
         return self.delay_update_array
 
     def py_get_delay_update_array(self):
+        """Return the stoichiometric matrix for delayed changes.
+
+        Returns
+        -------
+        numpy.ndarray
+            A 2-D array with 1 row per species, 1 column per
+            reaction.
+        """
         return self.delay_update_array
 
-
     def get_param_index(self, param_name):
+        """Return the index of a parameter, or -1 if not found.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name.
+        """
         if param_name in self.params2index:
             return self.params2index[param_name]
         return -1
 
     def get_species_index(self, species_name):
+        """Return the index of a species, or -1 if not found.
+
+        Parameters
+        ----------
+        species_name : str
+            The species name.
+        """
         if species_name in self.species2index:
             return self.species2index[species_name]
         return -1
 
     def get_param_value(self, param_name):
+        """Return the value of a parameter.
+
+        Parameters
+        ----------
+        param_name : str
+            The parameter name.
+
+        Raises
+        ------
+        LookupError
+            If no parameter with that name exists in the model.
+        """
         if param_name in self.params2index:
             return self.params_values[self.params2index[param_name]]
         else:
             raise LookupError('No parameter with name '+ param_name)
 
     def get_species_value(self, species_name):
+        """Return the value of a species.
+
+        Parameters
+        ----------
+        species_name : str
+            The species name.
+
+        Raises
+        ------
+        LookupError
+            If no species with that name exists in the model.
+        """
         if species_name in self.species2index:
             return self.species_values[self.species2index[species_name]]
         else:
             raise LookupError('No species with name '+ species_name)
 
-
     def parse_general_expression(self, instring):
+        """Parse a symbolic expression string into a `Term` tree.
+
+        Parameters
+        ----------
+        instring : str
+            The expression to parse, in terms of this model's
+            species and parameter names.
+
+        Returns
+        -------
+        Term
+            The root of the parsed expression tree.
+        """
         return parse_expression(instring,self.species2index,self.params2index)
 
 
-    #Generates an SBML Model
     def generate_sbml_model(self, stochastic_model = False, **keywords):
+        """Build an SBML representation of this model.
+
+        Parameters
+        ----------
+        stochastic_model : bool, default False
+            If True, annotate reactions for stochastic simulation.
+        **keywords
+            Additional keyword arguments forwarded to
+            `create_sbml_model`.
+
+        Returns
+        -------
+        document : libsbml.SBMLDocument
+            The generated SBML document.
+        model : libsbml.Model
+            The generated SBML model.
+        """
         # Create an empty SBMLDocument object to hold the bioscrape model
         document, model = create_sbml_model(**keywords)
 
@@ -2493,8 +3456,24 @@ cdef class Model:
             print(err_message)
         return document, model
 
-    #write an SBML Model
     def write_sbml_model(self, file_name, stochastic_model = False, **keywords):
+        """Write this model to a file in SBML format.
+
+        Parameters
+        ----------
+        file_name : str
+            Path to write the SBML file to.
+        stochastic_model : bool, default False
+            If True, annotate reactions for stochastic simulation.
+        **keywords
+            Additional keyword arguments forwarded to
+            `generate_sbml_model`.
+
+        Returns
+        -------
+        bool
+            True on success.
+        """
         document, _ = self.generate_sbml_model(stochastic_model = stochastic_model, **keywords)
         sbml_string = libsbml.writeSBMLToString(document)
         with open(file_name, 'w') as f:
@@ -2502,11 +3481,16 @@ cdef class Model:
         return True
 
     def get_reaction_strings(self):
-        '''
-        Returns a list of strings describing the reactions of this Model.
+        """Return a list of strings describing the model's reactions.
 
-        NOT delay-compatible. 
-        '''
+        Not delay-compatible.
+
+        Returns
+        -------
+        list of str
+            One string per reaction, formatted as
+            ``"reactants ->[propensity] products"``.
+        """
         reaction_strings = []
 
         # Propensity objects can only report their string descriptions in terms of 
@@ -2541,12 +3525,17 @@ cdef class Model:
         return reaction_strings
 
     def get_derivative_strings(self):
-        '''
-        Returns a dictionary mapping species names to string descriptions of their ODE dynamics.
+        """Return each species' ODE dynamics as a string.
 
-        NOT delay-compatible.
-        '''
-        # Propensity objects can only report their string descriptions in terms of 
+        Not delay-compatible.
+
+        Returns
+        -------
+        dict of str to str
+            Maps each species name to a string description of its
+            ODE right-hand side.
+        """
+        # Propensity objects can only report their string descriptions in terms of
         # species and parameter indices in this model. We'll need to fill those in with
         # concrete species and parameter names using this dictionary.
         decoding_args = {}
@@ -2655,15 +3644,37 @@ cdef class Model:
 #################################################                     ################################################
 
 cdef class Schnitz:
-    def __init__(self, time, data, volume):
-        """
-        Create a Schnitz with the provided time, data, and volume arrays. Parents and daughters are left as None and
-        must be set later if required.
+    """The data acquired from a single cell trajectory.
 
-        :param time: (np.ndarray) 1-D array with time points
-        :param data: (np.ndarray) 2-D array with one row for each time point, one column for each measured output
-        :param volume: (np.ndarray) 1-D array with volume at each time point
-        """
+    Parents and daughters are left as None and must be set later if
+    required.
+
+    Parameters
+    ----------
+    time : numpy.ndarray
+        1-D array with time points.
+    data : numpy.ndarray
+        2-D array with one row for each time point, one column for
+        each measured output.
+    volume : numpy.ndarray
+        1-D array with volume at each time point.
+
+    Attributes
+    ----------
+    data : numpy.ndarray
+        2-D array with one row for each time point, one column for
+        each measured output.
+    time : numpy.ndarray
+        1-D array with the time points.
+    volume : numpy.ndarray
+        1-D array with the volume at each time point.
+    parent : Schnitz
+        The parent cell's Schnitz, or None if it has no parent.
+    daughter1, daughter2 : Schnitz
+        The daughter cells' Schnitzes, or None if they don't exist.
+    """
+    def __init__(self, time, data, volume):
+        """See class docstring."""
         self.parent = None
         self.daughter1 = None
         self.daughter2 = None
@@ -2672,18 +3683,36 @@ cdef class Schnitz:
         self.data = data
 
     def py_get_data(self):
+        """Return the 2-D array of measured outputs."""
         return self.data
 
     def py_set_data(self, data):
+        """Set the 2-D array of measured outputs."""
         self.data = data
 
     def py_get_time(self):
+        """Return the 1-D array of time points."""
         return self.time
 
     def py_get_volume(self):
+        """Return the 1-D array of volumes."""
         return self.volume
 
     def py_get_dataframe(self, Model = None):
+        """Return this Schnitz's data as a pandas DataFrame.
+
+        Parameters
+        ----------
+        Model : Model, optional
+            If given, used to label the data columns with species
+            names. Otherwise the columns are left unnamed.
+
+        Returns
+        -------
+        pandas.DataFrame or numpy.ndarray
+            The data, time, and volume as a DataFrame, or (if
+            pandas is not installed) the raw data array.
+        """
         try:
             import pandas
             if Model == None:
@@ -2701,20 +3730,38 @@ cdef class Schnitz:
             return self.py_get_result()
 
     def py_get_parent(self):
+        """Return the parent cell's Schnitz, or None."""
         return self.parent
 
     def py_get_daughters(self):
+        """Return the `(daughter1, daughter2)` Schnitz tuple."""
         return (self.daughter1, self.daughter2)
 
-
     def py_set_parent(self, Schnitz p):
+        """Set the parent cell's Schnitz."""
         self.set_parent(p)
 
     def py_set_daughters(self,Schnitz d1, Schnitz d2):
+        """Set the daughter cells' Schnitzes."""
         self.set_daughters(d1,d2)
 
-
     def get_sub_lineage(self, dict species_dict = None):
+        """Return a `Lineage` rooted at this Schnitz.
+
+        Includes this Schnitz and all of its descendants.
+
+        Parameters
+        ----------
+        species_dict : dict, optional
+            If given, a species-name-to-index dict, and the result
+            is an `ExperimentalLineage` using it. Otherwise a plain
+            `Lineage` is returned.
+
+        Returns
+        -------
+        Lineage
+            The sub-lineage rooted at this Schnitz.
+        """
         cdef Lineage out
         if species_dict is None:
             out = Lineage()
@@ -2743,6 +3790,11 @@ cdef class Schnitz:
 
 
     def copy(self):
+        """Return a copy of this Schnitz.
+
+        `time`, `data`, and `volume` are deep-copied; `parent` and
+        the daughters are shared with the original.
+        """
         cdef Schnitz temp = Schnitz(self.time.copy(),self.data.copy(),self.volume.copy())
         temp.daughter1 = self.daughter1
         temp.daughter2 = self.daughter2
@@ -2761,24 +3813,38 @@ cdef class Schnitz:
         return (self.parent,self.daughter1,self.daughter2, self.time, self.volume, self.data)
 
 cdef class Lineage:
+    """A cell lineage consisting of many `Schnitz` objects.
+
+    Attributes
+    ----------
+    schnitzes : list of Schnitz
+        All of the Schnitzes in the lineage.
+    """
     def __init__(self):
-        """
-        Creates a lineage object.
-        """
+        """See class docstring."""
         self.schnitzes = []
 
     def py_size(self):
-        """
-        Get the total number of schnitzes in the lineage.
-        :return: (int) size of lineage
-        """
+        """Return the total number of Schnitzes in the lineage."""
         return self.c_schnitzes.size()
 
     def py_get_schnitz(self, unsigned index):
-        """
-        Get a specific schnitz from the lineage
-        :param index: (unsigned) the Schnitz to retrieve 0 <= index < size()
-        :return: (Schnitz) the requested Schnitz
+        """Return a specific Schnitz from the lineage.
+
+        Parameters
+        ----------
+        index : unsigned
+            The Schnitz to retrieve, ``0 <= index < py_size()``.
+
+        Returns
+        -------
+        Schnitz
+            The requested Schnitz.
+
+        Raises
+        ------
+        IndexError
+            If `index` is out of range.
         """
         if index >= self.py_size():
             raise IndexError(f"index {index} > lineage.py_size() = {self.py_size()}")
@@ -2786,6 +3852,7 @@ cdef class Lineage:
         return (<Schnitz> (self.c_schnitzes[index]))
 
     def py_add_schnitz(self, Schnitz s):
+        """Add a Schnitz to the lineage."""
         self.add_schnitz(s)
 
     def __setstate__(self, state):
@@ -2798,6 +3865,25 @@ cdef class Lineage:
         return (self.schnitzes,)
 
     def truncate_lineage(self,double start_time, double end_time):
+        """Return a copy of this lineage restricted to a time window.
+
+        Schnitzes entirely outside `[start_time, end_time]` are
+        dropped; remaining Schnitzes have their `time`/`data`/
+        `volume` arrays sliced to the window, with parent/daughter
+        links preserved between the kept Schnitzes.
+
+        Parameters
+        ----------
+        start_time : float
+            Start of the time window to keep.
+        end_time : float
+            End of the time window to keep.
+
+        Returns
+        -------
+        Lineage
+            The truncated lineage.
+        """
         cdef Schnitz sch, new_sch
         cdef dict sch_dict = {}
         cdef Lineage new_lineage = Lineage()
@@ -2833,8 +3919,16 @@ cdef class Lineage:
 
         return new_lineage
 
-    #Returns the same tree as above
     def get_schnitzes_by_generation(self):
+        """Group this lineage's Schnitzes by generation.
+
+        Returns
+        -------
+        list of list of Schnitz
+            One list per generation; generation 0 holds the
+            Schnitzes with no parent, generation 1 their daughters,
+            and so on.
+        """
         #print("Creating Schnitz Tree")
         sch_tree = [[]]
         sch_tree_length = 1
@@ -2854,14 +3948,37 @@ cdef class Lineage:
 
 
 cdef class ExperimentalLineage(Lineage):
+    """A `Lineage` whose Schnitz data columns map to species names.
+
+    Parameters
+    ----------
+    species_indices : dict of str to int, default {}
+        Maps species names to their column index in each Schnitz's
+        data array.
+    """
     def __init__(self, dict species_indices={}):
+        """See class docstring."""
         super().__init__()
         self.species_dict = species_indices
 
     def py_set_species_indices(self, dict species_indices):
+        """Set the species-name-to-data-column-index mapping."""
         self.species_dict = species_indices.copy()
 
     def py_get_species_index(self, str species):
+        """Return the data column index for a species.
+
+        Parameters
+        ----------
+        species : str
+            The species name.
+
+        Returns
+        -------
+        int
+            The column index, or -1 (with a warning) if `species`
+            is not in the mapping.
+        """
         if species in self.species_dict:
             return self.species_dict[species]
         warnings.warn('Species not found in experimental lineage: %s\n' % species)
@@ -2875,6 +3992,23 @@ cdef class ExperimentalLineage(Lineage):
         return super().__getstate__() + (self.species_dict,)
 
     def truncate_lineage(self,double start_time, double end_time):
+        """Return a copy of this lineage restricted to a time window.
+
+        Same as `Lineage.truncate_lineage`, but preserves the
+        species-index mapping on the returned `ExperimentalLineage`.
+
+        Parameters
+        ----------
+        start_time : float
+            Start of the time window to keep.
+        end_time : float
+            End of the time window to keep.
+
+        Returns
+        -------
+        ExperimentalLineage
+            The truncated lineage.
+        """
         cdef Schnitz sch, new_sch
         cdef dict sch_dict = {}
         cdef ExperimentalLineage new_lineage = ExperimentalLineage()

--- a/bioscrape/types.pyx
+++ b/bioscrape/types.pyx
@@ -42,6 +42,7 @@ cdef class Propensity:
     when a species reacts with itself).
     """
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.unset
 
     def py_get_propensity(self, np.ndarray[np.double_t,ndim=1] state, np.ndarray[np.double_t,ndim=1] params,
@@ -175,7 +176,7 @@ cdef class ConstitutivePropensity(Propensity):
     ``propensity_type='massaction'`` reactions with zero reactant
     species (the fastest of the specialized mass-action propensities);
     not normally constructed directly. Recognized
-    `propensity_param_dict` key: `k` (the rate parameter name).
+    `propensity_param_dict` key: 'k' (the rate parameter name).
 
     Attributes
     ----------
@@ -184,6 +185,7 @@ cdef class ConstitutivePropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.constitutive
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -217,8 +219,8 @@ cdef class UnimolecularPropensity(Propensity):
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with one reactant
     species; not normally constructed directly. Recognized
-    `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the reactant species name x).
+    `propensity_param_dict` keys: 'k' (the rate parameter name) and
+    'species' (the reactant species name x).
 
     Attributes
     ----------
@@ -229,6 +231,7 @@ cdef class UnimolecularPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.unimolecular
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -265,8 +268,8 @@ cdef class BimolecularPropensity(Propensity):
     Selected automatically by `~Model.create_reaction` for
     ``propensity_type='massaction'`` reactions with two reactant
     species; not normally constructed directly. Recognized
-    `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the two reactant species names, e.g. 'A*B'). If the
+    `propensity_param_dict` keys: 'k' (the rate parameter name) and
+    'species' (the two reactant species names, e.g. 'A*B'). If the
     two species are the same (e.g. 'A*A'), the stochastic
     propensity accounts for the discrete copy-number effect of a
     species reacting with itself: rate = k*x1*(x1 - 1).
@@ -282,6 +285,7 @@ cdef class BimolecularPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.bimolecular
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -331,8 +335,8 @@ cdef class PositiveHillPropensity(Propensity):
 
     Constructed via `~Model.create_reaction` with
     ``propensity_type='hillpositive'``. Recognized
-    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), and `s1` (the species x1).
+    `propensity_param_dict` keys: 'k' (rate), 'K' (Hill constant),
+    'n' (cooperativity/Hill coefficient), and 's1' (the species x1).
 
     Attributes
     ----------
@@ -347,6 +351,7 @@ cdef class PositiveHillPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.hill_positive
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -397,9 +402,9 @@ cdef class PositiveProportionalHillPropensity(Propensity):
     rate = k*d*(x1/K)^n / (1 + (x1/K)^n). Constructed via
     `~Model.create_reaction` with
     ``propensity_type='proportionalhillpositive'``. Recognized
-    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), `s1` (the species x1),
-    and `d` (the proportional species d, e.g. an enzyme or
+    `propensity_param_dict` keys: 'k' (rate), 'K' (Hill constant),
+    'n' (cooperativity/Hill coefficient), 's1' (the species x1),
+    and 'd' (the proportional species d, e.g. an enzyme or
     polymerase whose abundance scales the rate).
 
     Attributes
@@ -417,6 +422,7 @@ cdef class PositiveProportionalHillPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.proportional_hill_positive
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -472,8 +478,8 @@ cdef class NegativeHillPropensity(Propensity):
 
     Constructed via `~Model.create_reaction` with
     ``propensity_type='hillnegative'``. Recognized
-    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), and `s1` (the repressor
+    `propensity_param_dict` keys: 'k' (rate), 'K' (Hill constant),
+    'n' (cooperativity/Hill coefficient), and 's1' (the repressor
     species x1).
 
     Attributes
@@ -489,6 +495,7 @@ cdef class NegativeHillPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.hill_negative
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -534,9 +541,9 @@ cdef class NegativeProportionalHillPropensity(Propensity):
     rate = k*d / (1 + (x1/K)^n). Constructed via
     `~Model.create_reaction` with
     ``propensity_type='proportionalhillnegative'``. Recognized
-    `propensity_param_dict` keys: `k` (rate), `K` (Hill constant),
-    `n` (cooperativity/Hill coefficient), `s1` (the repressor species
-    x1), and `d` (the proportional species d).
+    `propensity_param_dict` keys: 'k' (rate), 'K' (Hill constant),
+    'n' (cooperativity/Hill coefficient), 's1' (the repressor species
+    x1), and 'd' (the proportional species d).
 
     Attributes
     ----------
@@ -553,6 +560,7 @@ cdef class NegativeProportionalHillPropensity(Propensity):
     """
     # constructor
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.proportional_hill_negative
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -656,9 +664,9 @@ cdef class MassActionPropensity(Propensity):
     `UnimolecularPropensity`, and `BimolecularPropensity` are used
     instead for zero, one, and two reactant species respectively);
     not normally constructed directly. Recognized
-    `propensity_param_dict` keys: `k` (the rate parameter name) and
-    `species` (the reactant species names, e.g. 'A*A*B' for a
-    reaction where species `A` appears with multiplicity 2). The
+    `propensity_param_dict` keys: 'k' (the rate parameter name) and
+    'species' (the reactant species names, e.g. 'A*A*B' for a
+    reaction where species 'A' appears with multiplicity 2). The
     deterministic propensity multiplies each distinct species once;
     the stochastic propensity additionally accounts for repeated
     species via falling-factorial terms (e.g. x*(x-1) for a species
@@ -674,6 +682,7 @@ cdef class MassActionPropensity(Propensity):
         The parameter index of the rate k.
     """
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.mass_action
 
     cdef double get_propensity(self, double* state, double* params, double time):
@@ -820,6 +829,7 @@ cdef class ConstantTerm(Term):
     """
 
     def __init__(self, double val):
+        """See class docstring."""
         self.value = val
 
     cdef double evaluate(self, double *species, double *params, double time):
@@ -841,6 +851,7 @@ cdef class SpeciesTerm(Term):
         The species index.
     """
     def __init__(self, unsigned ind):
+        """See class docstring."""
         self.index = ind
 
     cdef double evaluate(self, double *species, double *params, double time):
@@ -862,6 +873,7 @@ cdef class ParameterTerm(Term):
         The parameter index.
     """
     def __init__(self, unsigned ind):
+        """See class docstring."""
         self.index = ind
 
     cdef double evaluate(self, double *species, double *params, double time):
@@ -914,6 +926,7 @@ cdef class BinaryTerm(Term):
     terms added via `py_add_term`.
     """
     def __init__(self):
+        """See class docstring."""
         self.terms_list = []
 
     def __reduce__(self):
@@ -1277,7 +1290,7 @@ cdef class GeneralPropensity(Propensity):
 
     Constructed via `~Model.create_reaction` with
     ``propensity_type='general'``. Recognized
-    `propensity_param_dict` key: `rate`, a string expression in
+    `propensity_param_dict` key: 'rate', a string expression in
     species and parameter names (e.g. 'k*A*B'), parsed into a
     `Term` expression tree via `parse_expression`.
     """
@@ -1288,6 +1301,7 @@ cdef class GeneralPropensity(Propensity):
         return self.term.volume_evaluate(state,params,volume,time)
 
     def __init__(self):
+        """See class docstring."""
         self.propensity_type = PropensityType.general
 
     def initialize(self, dict dictionary, dict species2index, dict params2index):
@@ -1347,6 +1361,7 @@ cdef class Delay:
         The type of delay.
     """
     def __init__(self):
+        """See class docstring."""
         self.delay_type = DelayType.unset_delay
 
     def py_get_delay(self, np.ndarray[np.double_t,ndim=1] state,
@@ -1430,6 +1445,7 @@ cdef class Delay:
 cdef class NoDelay(Delay):
     """A delay of 0.0 (no delay); the default when no delay is specified."""
     def __init__(self):
+        """See class docstring."""
         self.delay_type = DelayType.none
 
     cdef double get_delay(self, double* state, double* params):
@@ -1440,7 +1456,7 @@ cdef class FixedDelay(Delay):
     A fixed (deterministic) delay.
 
     Constructed via `~Model.create_reaction` with
-    ``delay_type='fixed'``. Recognized `delay_param_dict` key: `delay`
+    ``delay_type='fixed'``. Recognized `delay_param_dict` key: 'delay'
     (the name of the parameter giving the fixed delay value).
 
     Attributes
@@ -1450,6 +1466,7 @@ cdef class FixedDelay(Delay):
     """
 
     def __init__(self):
+        """See class docstring."""
         self.delay_type = DelayType.fixed
 
     cdef double get_delay(self, double* state, double* params):
@@ -1473,7 +1490,7 @@ cdef class GaussianDelay(Delay):
 
     Constructed via `~Model.create_reaction` with
     ``delay_type='gaussian'``. Recognized `delay_param_dict` keys:
-    `mean` and `std` (parameter names giving the distribution's mean
+    'mean' and 'std' (parameter names giving the distribution's mean
     and standard deviation).
 
     Attributes
@@ -1485,6 +1502,7 @@ cdef class GaussianDelay(Delay):
     """
 
     def __init__(self):
+        """See class docstring."""
         self.delay_type = DelayType.gaussian
 
     cdef double get_delay(self, double* state, double* params):
@@ -1516,8 +1534,8 @@ cdef class GammaDelay(Delay):
     mean k*theta and variance k*theta^2.
 
     Constructed via `~Model.create_reaction` with
-    ``delay_type='gamma'``. Recognized `delay_param_dict` keys: `k`
-    and `theta` (parameter names giving the shape and scale).
+    ``delay_type='gamma'``. Recognized `delay_param_dict` keys: 'k'
+    and 'theta' (parameter names giving the shape and scale).
 
     Attributes
     ----------
@@ -1528,6 +1546,7 @@ cdef class GammaDelay(Delay):
     """
 
     def __init__(self):
+        """See class docstring."""
         self.delay_type = DelayType.gamma
 
     cdef double get_delay(self, double* state, double* params):
@@ -1806,10 +1825,10 @@ cdef class GeneralODERule(Rule):
 
     Constructed via `~Model.create_rule` with ``rule_type='ode'``
     (frequency is forced to fire once per simulation time step).
-    `rule_attributes` must contain `target` (the destination species
-    or parameter name) and `equation` (a symbolic expression `f`,
+    `rule_attributes` must contain 'target' (the destination species
+    or parameter name) and 'equation' (a symbolic expression `f`,
     parsed via `parse_expression`); each firing adds
-    ``f(state, params, time) * dt`` to the target's current value (a
+    f(state, params, time) * dt to the target's current value (a
     first-order Euler step).
     """
     cdef void rule_operation(self, double *state, double *params, double time, double dt):
@@ -2074,6 +2093,7 @@ cdef class StochasticTimeThresholdVolume(Volume):
         The volume growth rate g, where dV/dt = g*V.
     """
     def __init__(self, double cell_cycle_time, double average_division_volume, double division_noise):
+        """See class docstring."""
         self.cell_cycle_time = cell_cycle_time
         self.average_division_volume = average_division_volume
         self.division_noise = division_noise
@@ -2164,6 +2184,7 @@ cdef class StateDependentVolume(Volume):
     """
 
     def __init__(self):
+        """See class docstring."""
         pass
 
     def setup(self, double average_division_volume, double division_noise, growth_rate, Model m):
@@ -3831,7 +3852,7 @@ cdef class Lineage:
         Parameters
         ----------
         index : unsigned
-            The Schnitz to retrieve, ``0 <= index < py_size()``.
+            The Schnitz to retrieve, 0 <= index < py_size().
 
         Returns
         -------

--- a/contributing.md
+++ b/contributing.md
@@ -28,6 +28,39 @@ All pull requests should be made to the `dev` branch of Bioscrape. To maintain c
 * Following the PEP8 guideline, limit the first line to 72 characters or less
 * Reference issues and pull requests in your pull request comment 
 
+### Docstrings
+
+Docstrings in `bioscrape/*.py`, `*.pyx`, `*.pxd`, and `lineage/*.pyx`
+follow the numpydoc convention (see the [numpydoc style guide](
+https://numpydoc.readthedocs.io/en/latest/format.html)), prioritizing
+what reads well as plain text via `help()`/`obj.__doc__`, since this
+package isn't always built alongside its Sphinx documentation.
+
+* Wrap docstring *text* (not code) to ~78 characters, greedily. Don't
+  break a wrap point inside a single- or double-backtick span.
+* The one-line summary (first line) must fit on a single physical
+  line, ≤75 characters, start with a capital letter, and end with a
+  period. If it doesn't fit, shorten it and move detail into the
+  extended summary or Parameters/Returns instead of wrapping it.
+* Avoid LaTeX/math notation (`$...$`) in docstrings -- it doesn't
+  render in a terminal. Write formulas in plain text, e.g.
+  `rate = k*(x1/K)^n / (1 + (x1/K)^n)` or `d(x_i)/d(p_j)`.
+* Use single backticks around Python objects and parameter names
+  (e.g. `` `Model` ``, `` `param_name` ``); double backticks for
+  inline code/short fragments. Quote plain strings with single quotes
+  (e.g. `'uniform'`), not double-backtick-wrapped. Write True/False/
+  None with no backticks, capitalized.
+* Class docstrings host the constructor's Parameters, not
+  `__init__`'s. Give `__init__` a one-line stub,
+  `"""See class docstring."""` -- leaving it with no docstring at all
+  is unsafe if it subclasses another documented class, since some
+  tools then fall back to the parent's `__init__` docs and silently
+  describe the wrong constructor. Classes should not have a "Returns"
+  section.
+* Every parameter and keyword argument must be documented.
+  Functions/attributes not meant for user access start with an
+  underscore (or, for Cython, are `cdef` rather than `def`/`cpdef`).
+
 ## Have any questions?
 
 If you have questions or would like to connect to the Bioscrape team on a regular basis, you can join our Slack channel. Bioscrape is a channel under the Synthetic Biology Modeling and Analysis Tools (SBTools) slack team.

--- a/lineage/lineage.pyx
+++ b/lineage/lineage.pyx
@@ -612,8 +612,8 @@ cdef class SpeciesDeathRule(DeathRule):
 	Constructed via `~LineageModel.create_death_rule` with
 	``rule_type='species'``. Recognized `param_dictionary` keys:
 	`specie` (the species name), `threshold` (a parameter name),
-	`comp` (one of ``'>'``/``'greater'``, ``'<'``/``'less'``, or
-	``'='``/``'equal'``; defaults to ``'>'`` with a warning if
+	`comp` (one of '>'/'greater', '<'/'less', or
+	'='/'equal'; defaults to '>' with a warning if
 	omitted), and, optionally, `noise` (a parameter name giving the
 	standard deviation of Gaussian noise added to `threshold`).
 	"""
@@ -675,8 +675,8 @@ cdef class ParamDeathRule(DeathRule):
 	Constructed via `~LineageModel.create_death_rule` with
 	``rule_type='param'``. Recognized `param_dictionary` keys:
 	`param` (the parameter name to compare), `threshold` (a
-	parameter name), `comp` (one of ``'>'``/``'greater'``,
-	``'<'``/``'less'``, or ``'='``/``'equal'``; defaults to ``'>'``
+	parameter name), `comp` (one of '>'/'greater',
+	'<'/'less', or '='/'equal'; defaults to '>'
 	with a warning if omitted), and, optionally, `noise` (a
 	parameter name giving the standard deviation of Gaussian noise
 	added to `threshold`).
@@ -805,13 +805,15 @@ cdef class LineageModel(Model):
 		death rule types are routed to `create_volume_rule`/
 		`create_division_rule`/`create_death_rule`; other types go
 		to the base `~bioscrape.types.Model`. Only recognized when
-		`rule_type` itself contains the word ``'volume'``,
-		``'division'``, or ``'death'`` (e.g.
-		``'linearvolumerule'``, not the short form ``'linear'``),
+		`rule_type` itself contains the word 'volume',
+		'division', or 'death' (e.g.
+		'linearvolumerule', not the short form 'linear'),
 		and division rules are not currently usable this way at all
 		(no way to supply a `VolumeSplitter`) -- prefer
 		`create_volume_rule`/`create_division_rule`/
 		`create_death_rule` instead.
+		TODO: this paragraph describes a known routing bug
+		(see task_03993410); update or remove it once fixed.
 	events : list of tuple, default []
 		Event tuples `(event_type, event_params,
 		event_propensity_type, propensity_params)`. Routed like
@@ -1064,7 +1066,7 @@ cdef class LineageModel(Model):
 		propensity_param_dict : dict
 			The propensity's field dictionary.
 		event_type : str, optional
-			One of ``'division'``, ``'volume'``, or ``'death'``
+			One of 'division', 'volume', or 'death'
 			(several capitalizations/suffixes accepted).
 		volume_splitter : VolumeSplitter, optional
 			Required if `event_type` is a division event; used to
@@ -1112,9 +1114,9 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		event_type : str
-			Currently only the default type is supported: ``''``,
-			``'death'``, ``'deathevent'``, ``'death event'``, or
-			``'default'``.
+			Currently only the default type is supported: '',
+			'death', 'deathevent', 'death event', or
+			'default'.
 		event_params : dict
 			The event's field dictionary (unused by `DeathEvent`).
 		event_propensity_type : str
@@ -1145,9 +1147,9 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		event_type : str
-			Currently only the default type is supported: ``''``,
-			``'division'``, ``'divisionevent'``, ``'division
-			event'``, or ``'default'``.
+			Currently only the default type is supported: '',
+			'division', 'divisionevent', 'division event',
+			or 'default'.
 		event_params : dict
 			The event's field dictionary (unused by `DivisionEvent`).
 		event_propensity_type : str
@@ -1185,8 +1187,8 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		event_type : str
-			One of ``'linear'``, ``'multiplicative'``, or
-			``'general'`` (several capitalizations/suffixes
+			One of 'linear', 'multiplicative', or
+			'general' (several capitalizations/suffixes
 			accepted); see `LinearVolumeEvent`,
 			`MultiplicativeVolumeEvent`, `GeneralVolumeEvent` for
 			the corresponding `event_params` keys.
@@ -1240,8 +1242,8 @@ cdef class LineageModel(Model):
 			The rule's field dictionary (passed to
 			`LineageRule.initialize`).
 		rule_type : str
-			Must contain (case-insensitively) ``'division'``,
-			``'death'``, or ``'volume'``.
+			Must contain (case-insensitively) 'division',
+			'death', or 'volume'.
 		volume_splitter : VolumeSplitter, optional
 			Required if `rule_type` is a division rule; used to
 			partition the daughter cells.
@@ -1279,8 +1281,8 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		rule_type : str
-			One of ``'species'``, ``'param'``/``'parameter'``, or
-			``'general'`` (or their `*DeathRule` class-name-style
+			One of 'species', 'param'/'parameter', or
+			'general' (or their `*DeathRule` class-name-style
 			aliases); see `SpeciesDeathRule`, `ParamDeathRule`,
 			`GeneralDeathRule` for the corresponding
 			`rule_param_dict` keys.
@@ -1317,8 +1319,8 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		rule_type : str
-			One of ``'time'``, ``'volume'``, ``'delta'``/
-			``'deltaV'``, or ``'general'`` (or their
+			One of 'time', 'volume', 'delta'/
+			'deltaV', or 'general' (or their
 			`*DivisionRule` class-name-style aliases); see
 			`TimeDivisionRule`, `VolumeDivisionRule`,
 			`DeltaVDivisionRule`, `GeneralDivisionRule` for the
@@ -1361,8 +1363,8 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		rule_type : str
-			One of ``'linear'``, ``'multiplicative'``,
-			``'assignment'``, or ``'ode'`` (or their `*VolumeRule`
+			One of 'linear', 'multiplicative',
+			'assignment', or 'ode' (or their `*VolumeRule`
 			class-name-style aliases); see `LinearVolumeRule`,
 			`MultiplicativeVolumeRule`, `AssignmentVolumeRule`,
 			`ODEVolumeRule` for the corresponding `rule_param_dict`
@@ -2039,9 +2041,9 @@ cdef class LineageVolumeSplitter(VolumeSplitter):
 	"""Splits a cell's volume and species between two daughter cells.
 
 	Each species (and the volume itself) can be partitioned
-	independently: ``'binomial'`` (each molecule independently goes
-	to one daughter with probability ~0.5), ``'perfect'``
-	(proportional to volume, +/- 1 for rounding), ``'duplicate'``
+	independently: 'binomial' (each molecule independently goes
+	to one daughter with probability ~0.5), 'perfect'
+	(proportional to volume, +/- 1 for rounding), 'duplicate'
 	(both daughters get the parent's full count), or a named entry
 	in `custom_partition_functions`.
 
@@ -2050,12 +2052,12 @@ cdef class LineageVolumeSplitter(VolumeSplitter):
 	M : Model
 		The model whose species are being partitioned.
 	options : dict, default {}
-		Maps a species name (or the special keys ``'default'`` and
-		``'volume'``) to its partitioning mode: ``'binomial'``,
-		``'perfect'``, ``'duplicate'``, or a key in
+		Maps a species name (or the special keys 'default' and
+		'volume') to its partitioning mode: 'binomial',
+		'perfect', 'duplicate', or a key in
 		`custom_partition_functions`. Species not listed use the
-		``'default'`` entry's mode (``'binomial'`` if not given);
-		``'volume'`` defaults to the same mode as ``'default'``.
+		'default' entry's mode ('binomial' if not given);
+		'volume' defaults to the same mode as 'default'.
 	custom_partition_functions : dict, optional
 		Maps a name to a callable used when that name is given as a
 		partitioning mode in `options`.
@@ -4825,8 +4827,8 @@ def py_set_up_InteractingLineage(global_species = [], interface_list = [],
 		Required when using `interface_list` instead of `model_list`.
 	global_volume_simulator : str, default "stochastic"
 		Simulator type for the optional shared-environment CRN given
-		by `global_volume_model`: ``'stochastic'`` or
-		``'deterministic'``.
+		by `global_volume_model`: 'stochastic' or
+		'deterministic'.
 	global_volume_model : Model, optional
 		A `~bioscrape.types.Model` describing reactions in the
 		shared extracellular environment (e.g. degradation of a
@@ -4967,8 +4969,8 @@ def py_PropagateInteractingCells(timepoints, global_sync_period,
 		`InteractingLineageSSASimulator`.
 	global_volume_simulator : str, default "stochastic"
 		Simulator type for the optional shared-environment CRN given
-		by `global_volume_model`: ``'stochastic'`` or
-		``'deterministic'``.
+		by `global_volume_model`: 'stochastic' or
+		'deterministic'.
 	global_volume_model : Model, optional
 		A `~bioscrape.types.Model` describing reactions in the
 		shared extracellular environment. If not given, global
@@ -5108,8 +5110,8 @@ def py_SimulateInteractingCellLineage(timepoints, global_sync_period,
 		`InteractingLineageSSASimulator`.
 	global_volume_simulator : str, default "stochastic"
 		Simulator type for the optional shared-environment CRN given
-		by `global_volume_model`: ``'stochastic'`` or
-		``'deterministic'``.
+		by `global_volume_model`: 'stochastic' or
+		'deterministic'.
 	global_volume_model : Model, optional
 		A `~bioscrape.types.Model` describing reactions in the
 		shared extracellular environment. If not given, global

--- a/lineage/lineage.pyx
+++ b/lineage/lineage.pyx
@@ -109,11 +109,11 @@ cdef class VolumeEvent(Event):
 		raise NotImplementedError("VolumeReactions Must be subclassed")
 
 cdef class LinearVolumeEvent(VolumeEvent):
-	"""Sets volume to ``volume + growth_rate`` when the event fires.
+	"""Sets volume to volume + growth_rate when the event fires.
 
 	Constructed via `~LineageModel.create_volume_event` with
 	``event_type='linear'``. Recognized `event_params` key:
-	`growth_rate` (a parameter name).
+	'growth_rate' (a parameter name).
 	"""
 	cdef unsigned growth_rate_ind
 
@@ -131,11 +131,11 @@ cdef class LinearVolumeEvent(VolumeEvent):
 		return ([], [event_fields["growth_rate"]])
 
 cdef class MultiplicativeVolumeEvent(VolumeEvent):
-	"""Sets volume to ``volume * (1 + growth_rate)`` when it fires.
+	"""Sets volume to volume * (1 + growth_rate) when it fires.
 
 	Constructed via `~LineageModel.create_volume_event` with
 	``event_type='multiplicative'``. Recognized `event_params` key:
-	`growth_rate` (a parameter name).
+	'growth_rate' (a parameter name).
 	"""
 	cdef unsigned growth_rate_ind
 	cdef Term volume_equation
@@ -159,7 +159,7 @@ cdef class GeneralVolumeEvent(VolumeEvent):
 
 	Constructed via `~LineageModel.create_volume_event` with
 	``event_type='general'``. Recognized `event_params` key:
-	`equation` (a symbolic expression string, parsed via
+	'equation' (a symbolic expression string, parsed via
 	`~bioscrape.types.parse_expression`; may reference species,
 	parameters, and `volume`).
 	"""
@@ -281,13 +281,13 @@ cdef class VolumeRule(LineageRule):
 		raise NotImplementedError("get_volume must be implemented in VolumeRule Subclasses")
 
 cdef class LinearVolumeRule(VolumeRule):
-	"""Grows volume linearly: ``volume += growth_rate * dt`` (+noise).
+	"""Grows volume linearly: volume += growth_rate * dt (+noise).
 
 	Constructed via `~LineageModel.create_volume_rule` with
 	``rule_type='linear'``. Recognized `param_dictionary` keys:
-	`growth_rate` (a parameter name) and, optionally, `noise` (a
+	'growth_rate' (a parameter name) and, optionally, 'noise' (a
 	parameter name giving the standard deviation of Gaussian noise
-	added to `growth_rate` at each step).
+	added to 'growth_rate' at each step).
 	"""
 	cdef unsigned has_noise
 	cdef unsigned growth_rate_ind
@@ -317,13 +317,13 @@ cdef class LinearVolumeRule(VolumeRule):
 			return ([], [fields["growth_rate"]])
 
 cdef class MultiplicativeVolumeRule(VolumeRule):
-	"""Grows volume exponentially: ``volume += volume*growth_rate*dt``.
+	"""Grows volume exponentially: volume += volume*growth_rate*dt.
 
 	Constructed via `~LineageModel.create_volume_rule` with
 	``rule_type='multiplicative'``. Recognized `param_dictionary`
-	keys: `growth_rate` (a parameter name) and, optionally, `noise`
+	keys: 'growth_rate' (a parameter name) and, optionally, 'noise'
 	(a parameter name giving the standard deviation of Gaussian
-	noise added to `growth_rate` at each step).
+	noise added to 'growth_rate' at each step).
 	"""
 	cdef unsigned has_noise
 	cdef unsigned growth_rate_ind
@@ -357,7 +357,7 @@ cdef class AssignmentVolumeRule(VolumeRule):
 
 	Constructed via `~LineageModel.create_volume_rule` with
 	``rule_type='assignment'``. Recognized `param_dictionary` key:
-	`equation` (a symbolic expression string, parsed via
+	'equation' (a symbolic expression string, parsed via
 	`~bioscrape.types.parse_expression`; may reference species,
 	parameters, and `volume`).
 	"""
@@ -379,11 +379,11 @@ cdef class AssignmentVolumeRule(VolumeRule):
 		return (species, parameters)
 
 cdef class ODEVolumeRule(VolumeRule):
-	"""Integrates volume via Euler's method: ``volume += equation*dt``.
+	"""Integrates volume via Euler's method: volume += equation*dt.
 
 	Constructed via `~LineageModel.create_volume_rule` with
 	``rule_type='ode'``. Recognized `param_dictionary` key:
-	`equation` (a symbolic expression string for dV/dt, parsed via
+	'equation' (a symbolic expression string for dV/dt, parsed via
 	`~bioscrape.types.parse_expression`; may reference species,
 	parameters, and `volume`).
 	"""
@@ -429,10 +429,10 @@ cdef class TimeDivisionRule(DivisionRule):
 
 	Constructed via `~LineageModel.create_division_rule` with
 	``rule_type='time'``. Recognized `param_dictionary` keys:
-	`threshold` (a parameter name giving the time since the cell's
-	birth at which it divides) and, optionally, `noise` (a parameter
+	'threshold' (a parameter name giving the time since the cell's
+	birth at which it divides) and, optionally, 'noise' (a parameter
 	name giving the standard deviation of Gaussian noise added to
-	`threshold`).
+	'threshold').
 	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
@@ -474,9 +474,9 @@ cdef class VolumeDivisionRule(DivisionRule):
 
 	Constructed via `~LineageModel.create_division_rule` with
 	``rule_type='volume'``. Recognized `param_dictionary` keys:
-	`threshold` (a parameter name giving the volume at which the
-	cell divides) and, optionally, `noise` (a parameter name giving
-	the standard deviation of Gaussian noise added to `threshold`).
+	'threshold' (a parameter name giving the volume at which the
+	cell divides) and, optionally, 'noise' (a parameter name giving
+	the standard deviation of Gaussian noise added to 'threshold').
 	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
@@ -519,10 +519,10 @@ cdef class DeltaVDivisionRule(DivisionRule):
 
 	Constructed via `~LineageModel.create_division_rule` with
 	``rule_type='deltaV'``. Recognized `param_dictionary` keys:
-	`threshold` (a parameter name giving the volume increase, since
+	'threshold' (a parameter name giving the volume increase, since
 	the cell's birth volume, at which it divides) and, optionally,
-	`noise` (a parameter name giving the standard deviation of
-	Gaussian noise added to `threshold`).
+	'noise' (a parameter name giving the standard deviation of
+	Gaussian noise added to 'threshold').
 	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
@@ -565,7 +565,7 @@ cdef class GeneralDivisionRule(DivisionRule):
 
 	Constructed via `~LineageModel.create_division_rule` with
 	``rule_type='general'``. Recognized `param_dictionary` key:
-	`equation` (a symbolic expression string, parsed via
+	'equation' (a symbolic expression string, parsed via
 	`~bioscrape.types.parse_expression`; the cell divides once this
 	evaluates to a value greater than 0).
 	"""
@@ -611,11 +611,11 @@ cdef class SpeciesDeathRule(DeathRule):
 
 	Constructed via `~LineageModel.create_death_rule` with
 	``rule_type='species'``. Recognized `param_dictionary` keys:
-	`specie` (the species name), `threshold` (a parameter name),
-	`comp` (one of '>'/'greater', '<'/'less', or
+	'specie' (the species name), 'threshold' (a parameter name),
+	'comp' (one of '>'/'greater', '<'/'less', or
 	'='/'equal'; defaults to '>' with a warning if
-	omitted), and, optionally, `noise` (a parameter name giving the
-	standard deviation of Gaussian noise added to `threshold`).
+	omitted), and, optionally, 'noise' (a parameter name giving the
+	standard deviation of Gaussian noise added to 'threshold').
 	"""
 	cdef unsigned has_noise
 	cdef unsigned species_ind
@@ -674,12 +674,12 @@ cdef class ParamDeathRule(DeathRule):
 
 	Constructed via `~LineageModel.create_death_rule` with
 	``rule_type='param'``. Recognized `param_dictionary` keys:
-	`param` (the parameter name to compare), `threshold` (a
-	parameter name), `comp` (one of '>'/'greater',
+	'param' (the parameter name to compare), 'threshold' (a
+	parameter name), 'comp' (one of '>'/'greater',
 	'<'/'less', or '='/'equal'; defaults to '>'
-	with a warning if omitted), and, optionally, `noise` (a
+	with a warning if omitted), and, optionally, 'noise' (a
 	parameter name giving the standard deviation of Gaussian noise
-	added to `threshold`).
+	added to 'threshold').
 	"""
 	cdef unsigned param_ind
 	cdef unsigned threshold_ind
@@ -739,7 +739,7 @@ cdef class GeneralDeathRule(DeathRule):
 
 	Constructed via `~LineageModel.create_death_rule` with
 	``rule_type='general'``. Recognized `param_dictionary` key:
-	`equation` (a symbolic expression string, parsed via
+	'equation' (a symbolic expression string, parsed via
 	`~bioscrape.types.parse_expression`; the cell dies once this
 	evaluates to a value greater than 0).
 	"""
@@ -1147,9 +1147,12 @@ cdef class LineageModel(Model):
 		Parameters
 		----------
 		event_type : str
-			Currently only the default type is supported: '',
-			'division', 'divisionevent', 'division event',
-			or 'default'.
+			`DivisionEvent` has no subtypes (unlike `VolumeEvent`, which
+			has `LinearVolumeEvent`/`MultiplicativeVolumeEvent`/
+			`GeneralVolumeEvent`), so this only validates the spelling
+			rather than choosing between alternatives. Accepted
+			(case-insensitive, all equivalent): '', 'division',
+			'divisionevent', 'division event', or 'default'.
 		event_params : dict
 			The event's field dictionary (unused by `DivisionEvent`).
 		event_propensity_type : str
@@ -1717,7 +1720,7 @@ cdef class SafeLineageCSimInterface(LineageCSimInterface):
 	See `~bioscrape.simulator.SafeModelCSimInterface`, which this
 	mirrors: warns (and zeroes out) negative propensities, and warns
 	if a species count or volume falls outside
-	``[0, max_species_count]``/``(0, max_volume]``.
+	[0, max_species_count]/(0, max_volume].
 
 	Parameters
 	----------

--- a/lineage/lineage.pyx
+++ b/lineage/lineage.pyx
@@ -1,6 +1,14 @@
 # cython: boundscheck=False
 # cython: cdivision=True
 # cython: wraparound=False
+"""
+Simulation of growing, dividing, and dying cell populations.
+
+A wrapper around `bioscrape.types` and `bioscrape.simulator` for
+lineage-level simulation. See `LineageModel` and `LineageSSASimulator`
+for the main entry points, and the module-level `py_Simulate*`/
+`py_Propagate*` functions for the simplest ways to run a simulation.
+"""
 
 import numpy as np
 import copy
@@ -39,14 +47,42 @@ import warnings
 
 import pandas
 
-# Events are general objects that happen with some internal propensity but are 
+# Events are general objects that happen with some internal propensity but are
 # not chemical reactions
 cdef class Event:
+	"""Base class for per-cell events fired by an internal propensity.
+
+	Like a reaction, an `Event` is associated with a `Propensity`
+	(from `bioscrape.types`) and fires stochastically according to
+	it, but instead of changing species counts it changes a cell's
+	volume, divides it, or kills it. Must be subclassed. Not
+	normally constructed directly -- attached to a `LineageModel` via
+	`~LineageModel.create_volume_event`,
+	`~LineageModel.create_division_event`, or
+	`~LineageModel.create_death_event`.
+	"""
 
 	cdef initialize(self, dict event_params, dict species_indices, dict parameter_indices):
 		raise NotImplementedError("VolumeReactions Must be subclassed")
 
 	def get_species_and_parameters(self, dict event_fields, dict species2index, dict params2index):
+		"""The species and parameter names referenced by this event.
+
+		Parameters
+		----------
+		event_fields : dict
+			The event's field dictionary (as passed to `initialize`).
+		species2index : dict
+			Maps species names to their index in the state vector.
+		params2index : dict
+			Maps parameter names to their index in the parameter
+			vector.
+
+		Returns
+		-------
+		tuple of list of str
+			`(species_names, parameter_names)`.
+		"""
 		raise NotImplementedError("VolumeReactions Must be subclassed")
 
 	#cdef Propensity get_propensity(self):
@@ -58,6 +94,11 @@ cdef class Event:
 
 #Volume Events are stochastic events which alter a single cell's volume.
 cdef class VolumeEvent(Event):
+	"""Base class for events that change a cell's volume when fired.
+
+	Subclasses implement `get_volume`. Attached to a `LineageModel`
+	via `~LineageModel.create_volume_event`.
+	"""
 	cdef double evaluate_event(self, double* state, double *params, double volume, double time):
 		return self.get_volume(state, params,volume, time)
 
@@ -68,6 +109,12 @@ cdef class VolumeEvent(Event):
 		raise NotImplementedError("VolumeReactions Must be subclassed")
 
 cdef class LinearVolumeEvent(VolumeEvent):
+	"""Sets volume to ``volume + growth_rate`` when the event fires.
+
+	Constructed via `~LineageModel.create_volume_event` with
+	``event_type='linear'``. Recognized `event_params` key:
+	`growth_rate` (a parameter name).
+	"""
 	cdef unsigned growth_rate_ind
 
 	cdef initialize(self, dict event_params, dict species_indices, dict parameter_indices):
@@ -84,6 +131,12 @@ cdef class LinearVolumeEvent(VolumeEvent):
 		return ([], [event_fields["growth_rate"]])
 
 cdef class MultiplicativeVolumeEvent(VolumeEvent):
+	"""Sets volume to ``volume * (1 + growth_rate)`` when it fires.
+
+	Constructed via `~LineageModel.create_volume_event` with
+	``event_type='multiplicative'``. Recognized `event_params` key:
+	`growth_rate` (a parameter name).
+	"""
 	cdef unsigned growth_rate_ind
 	cdef Term volume_equation
 
@@ -102,6 +155,14 @@ cdef class MultiplicativeVolumeEvent(VolumeEvent):
 		return ([], [event_fields["growth_rate"]])
 
 cdef class GeneralVolumeEvent(VolumeEvent):
+	"""Sets volume to an arbitrary expression's value when it fires.
+
+	Constructed via `~LineageModel.create_volume_event` with
+	``event_type='general'``. Recognized `event_params` key:
+	`equation` (a symbolic expression string, parsed via
+	`~bioscrape.types.parse_expression`; may reference species,
+	parameters, and `volume`).
+	"""
 	cdef Term volume_equation
 
 	cdef initialize(self, dict event_params, dict species_indices, dict parameter_indices):
@@ -122,6 +183,12 @@ cdef class GeneralVolumeEvent(VolumeEvent):
 
 #Division Events are stochastic events which cause a cell to divide using a particular VolumeSplitter
 cdef class DivisionEvent(Event):
+	"""An event that divides a cell (via a `VolumeSplitter`) when fired.
+
+	Attached to a `LineageModel` via
+	`~LineageModel.create_division_event`, which also takes the
+	`VolumeSplitter` used to partition the daughter cells.
+	"""
 	cdef initialize(self, dict event_params, dict species_indices, dict parameter_indices):
 		#self.propensity = propensity
 		#self.propensity.initialize(propensity_params, species_indices, parameter_indices)
@@ -141,6 +208,11 @@ cdef class DivisionEvent(Event):
 
 #Death Events are stochastic events which casue a cell to die
 cdef class DeathEvent(Event):
+	"""An event that kills a cell when fired.
+
+	Attached to a `LineageModel` via
+	`~LineageModel.create_death_event`.
+	"""
 	cdef initialize(self, dict event_params, dict species_indices, dict parameter_indices):
 		pass
 
@@ -154,18 +226,69 @@ cdef class DeathEvent(Event):
 
 #Dummy class to help with inheritance, compilation, and code simplification. Does nothing
 cdef class LineageRule(Rule):
+	"""Base class for lineage-specific rules.
+
+	Shared base for `VolumeRule`, `DivisionRule`, and `DeathRule`.
+	Must be subclassed.
+	"""
 	def initialize(self, dict param_dictionary, dict species_indices, dict parameter_indices, rule_frequency = "repeat"):
+		"""Configure this rule from its parameter dictionary.
+
+		Parameters
+		----------
+		param_dictionary : dict
+			The rule's field dictionary (recognized keys are
+			subclass-specific; see each subclass's docstring).
+		species_indices : dict
+			Maps species names to their index in the state vector.
+		parameter_indices : dict
+			Maps parameter names to their index in the parameter
+			vector.
+		rule_frequency : str, default "repeat"
+			When the rule fires; see
+			`~bioscrape.types.Rule.set_frequency_flag`.
+		"""
 		raise NotImplementedError("LineageRule must be subclassed")
 
 	def get_species_and_parameters(self, dict fields, dict species2index, dict params2index):
+		"""The species and parameter names referenced by this rule.
+
+		Parameters
+		----------
+		fields : dict
+			The rule's field dictionary (as passed to `initialize`).
+		species2index : dict
+			Maps species names to their index in the state vector.
+		params2index : dict
+			Maps parameter names to their index in the parameter
+			vector.
+
+		Returns
+		-------
+		tuple of list of str
+			`(species_names, parameter_names)`.
+		"""
 		raise NotImplementedError("LineageRule must be subclassed")
 
 #Volume Rules occur every dt (determined by the simulation timepoints) and update the volume
 cdef class VolumeRule(LineageRule):
+	"""Base class for rules that update a cell's volume every step.
+
+	Subclasses implement `get_volume`. Attached to a `LineageModel`
+	via `~LineageModel.create_volume_rule`.
+	"""
 	cdef double get_volume(self, double* state, double *params, double volume, double time, double dt):
 		raise NotImplementedError("get_volume must be implemented in VolumeRule Subclasses")
 
 cdef class LinearVolumeRule(VolumeRule):
+	"""Grows volume linearly: ``volume += growth_rate * dt`` (+noise).
+
+	Constructed via `~LineageModel.create_volume_rule` with
+	``rule_type='linear'``. Recognized `param_dictionary` keys:
+	`growth_rate` (a parameter name) and, optionally, `noise` (a
+	parameter name giving the standard deviation of Gaussian noise
+	added to `growth_rate` at each step).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned growth_rate_ind
 	cdef unsigned noise_ind
@@ -194,6 +317,14 @@ cdef class LinearVolumeRule(VolumeRule):
 			return ([], [fields["growth_rate"]])
 
 cdef class MultiplicativeVolumeRule(VolumeRule):
+	"""Grows volume exponentially: ``volume += volume*growth_rate*dt``.
+
+	Constructed via `~LineageModel.create_volume_rule` with
+	``rule_type='multiplicative'``. Recognized `param_dictionary`
+	keys: `growth_rate` (a parameter name) and, optionally, `noise`
+	(a parameter name giving the standard deviation of Gaussian
+	noise added to `growth_rate` at each step).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned growth_rate_ind
 	cdef unsigned noise_ind
@@ -222,6 +353,14 @@ cdef class MultiplicativeVolumeRule(VolumeRule):
 			return ([], [fields["growth_rate"]])
 
 cdef class AssignmentVolumeRule(VolumeRule):
+	"""Sets volume to an arbitrary expression's value at every step.
+
+	Constructed via `~LineageModel.create_volume_rule` with
+	``rule_type='assignment'``. Recognized `param_dictionary` key:
+	`equation` (a symbolic expression string, parsed via
+	`~bioscrape.types.parse_expression`; may reference species,
+	parameters, and `volume`).
+	"""
 	cdef Term volume_equation
 	cdef double get_volume(self, double* state, double *params, double volume, double time, double dt):
 		return (<Term>self.volume_equation).volume_evaluate(state,params,volume,time)
@@ -240,6 +379,14 @@ cdef class AssignmentVolumeRule(VolumeRule):
 		return (species, parameters)
 
 cdef class ODEVolumeRule(VolumeRule):
+	"""Integrates volume via Euler's method: ``volume += equation*dt``.
+
+	Constructed via `~LineageModel.create_volume_rule` with
+	``rule_type='ode'``. Recognized `param_dictionary` key:
+	`equation` (a symbolic expression string for dV/dt, parsed via
+	`~bioscrape.types.parse_expression`; may reference species,
+	parameters, and `volume`).
+	"""
 	cdef Term volume_equation
 	cdef double get_volume(self, double* state, double *params, double volume, double time, double dt):
 		return volume+(<Term>self.volume_equation).volume_evaluate(state,params,volume,time)*dt
@@ -260,6 +407,12 @@ cdef class ODEVolumeRule(VolumeRule):
 
 #Division rules are checked at the beginning of each simulation loop to see if a cell should divide
 cdef class DivisionRule(LineageRule):
+	"""Base class for rules checked each step to see if a cell divides.
+
+	Subclasses implement `check_divide`. Attached to a `LineageModel`
+	via `~LineageModel.create_division_rule`, which also takes the
+	`VolumeSplitter` used to partition the daughter cells.
+	"""
 
 	cdef int check_divide(self, double* state, double *params, double time, double volume, double initial_time, double initial_volume):
 		raise NotImplementedError("check_divide must be implemented in DivisionRule subclasses")
@@ -272,6 +425,15 @@ cdef class DivisionRule(LineageRule):
 
 #A division rule where division occurs after some amount of time (with an optional noise term)
 cdef class TimeDivisionRule(DivisionRule):
+	"""Divides a cell after a fixed time (+noise) since its birth.
+
+	Constructed via `~LineageModel.create_division_rule` with
+	``rule_type='time'``. Recognized `param_dictionary` keys:
+	`threshold` (a parameter name giving the time since the cell's
+	birth at which it divides) and, optionally, `noise` (a parameter
+	name giving the standard deviation of Gaussian noise added to
+	`threshold`).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
 	cdef unsigned threshold_noise_ind
@@ -308,6 +470,14 @@ cdef class TimeDivisionRule(DivisionRule):
 
 #A division rule where division occurs at some volume threshold (with an optional noise term)
 cdef class VolumeDivisionRule(DivisionRule):
+	"""Divides a cell once its volume passes a threshold (+noise).
+
+	Constructed via `~LineageModel.create_division_rule` with
+	``rule_type='volume'``. Recognized `param_dictionary` keys:
+	`threshold` (a parameter name giving the volume at which the
+	cell divides) and, optionally, `noise` (a parameter name giving
+	the standard deviation of Gaussian noise added to `threshold`).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
 	cdef unsigned threshold_noise_ind
@@ -345,6 +515,15 @@ cdef class VolumeDivisionRule(DivisionRule):
 
 #A division rule where division occurs after the cell has grown by some amount delta (with an optional noise term)
 cdef class DeltaVDivisionRule(DivisionRule):
+	"""Divides a cell once it has grown by a fixed amount (+noise).
+
+	Constructed via `~LineageModel.create_division_rule` with
+	``rule_type='deltaV'``. Recognized `param_dictionary` keys:
+	`threshold` (a parameter name giving the volume increase, since
+	the cell's birth volume, at which it divides) and, optionally,
+	`noise` (a parameter name giving the standard deviation of
+	Gaussian noise added to `threshold`).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned threshold_ind
 	cdef unsigned threshold_noise_ind
@@ -382,6 +561,14 @@ cdef class DeltaVDivisionRule(DivisionRule):
 #A general division rule
 #returns 1 if equation(state, params, volume, time) > 0
 cdef class GeneralDivisionRule(DivisionRule):
+	"""Divides a cell when an arbitrary expression becomes positive.
+
+	Constructed via `~LineageModel.create_division_rule` with
+	``rule_type='general'``. Recognized `param_dictionary` key:
+	`equation` (a symbolic expression string, parsed via
+	`~bioscrape.types.parse_expression`; the cell divides once this
+	evaluates to a value greater than 0).
+	"""
 	cdef Term equation
 	cdef int check_divide(self, double* state, double *params, double time, double volume, double initial_time, double intial_volume):
 		if (<Term> self.equation).volume_evaluate(state,params,volume,time) > 0:
@@ -404,6 +591,11 @@ cdef class GeneralDivisionRule(DivisionRule):
 
 #Death rules are checked at the beginning of each simulation loop to see if a cell should die
 cdef class DeathRule(LineageRule):
+	"""Base class for rules checked each step to see if a cell dies.
+
+	Subclasses implement `check_dead`. Attached to a `LineageModel`
+	via `~LineageModel.create_death_rule`.
+	"""
 	cdef int check_dead(self, double* state, double *params, double time, double volume, double initial_time, double initial_volume):
 		raise NotImplementedError("check_dead must be implemented in DeathRule subclasses.")
 
@@ -415,6 +607,16 @@ cdef class DeathRule(LineageRule):
 
 #A death rule where death occurs when some species is greater than or less than a given threshold
 cdef class SpeciesDeathRule(DeathRule):
+	"""Kills a cell by comparing a species count to a threshold.
+
+	Constructed via `~LineageModel.create_death_rule` with
+	``rule_type='species'``. Recognized `param_dictionary` keys:
+	`specie` (the species name), `threshold` (a parameter name),
+	`comp` (one of ``'>'``/``'greater'``, ``'<'``/``'less'``, or
+	``'='``/``'equal'``; defaults to ``'>'`` with a warning if
+	omitted), and, optionally, `noise` (a parameter name giving the
+	standard deviation of Gaussian noise added to `threshold`).
+	"""
 	cdef unsigned has_noise
 	cdef unsigned species_ind
 	cdef unsigned threshold_ind
@@ -468,6 +670,17 @@ cdef class SpeciesDeathRule(DeathRule):
 
 #A death rule where death occurs when some parameter is greater than or less than a given threshold
 cdef class ParamDeathRule(DeathRule):
+	"""Kills a cell by comparing a parameter's value to a threshold.
+
+	Constructed via `~LineageModel.create_death_rule` with
+	``rule_type='param'``. Recognized `param_dictionary` keys:
+	`param` (the parameter name to compare), `threshold` (a
+	parameter name), `comp` (one of ``'>'``/``'greater'``,
+	``'<'``/``'less'``, or ``'='``/``'equal'``; defaults to ``'>'``
+	with a warning if omitted), and, optionally, `noise` (a
+	parameter name giving the standard deviation of Gaussian noise
+	added to `threshold`).
+	"""
 	cdef unsigned param_ind
 	cdef unsigned threshold_ind
 	cdef unsigned threshold_noise_ind
@@ -522,6 +735,14 @@ cdef class ParamDeathRule(DeathRule):
 
 #A general death rule. Returns 1 if equation > 0. 0 otherwise
 cdef class GeneralDeathRule(DeathRule):
+	"""Kills a cell when an arbitrary expression becomes positive.
+
+	Constructed via `~LineageModel.create_death_rule` with
+	``rule_type='general'``. Recognized `param_dictionary` key:
+	`equation` (a symbolic expression string, parsed via
+	`~bioscrape.types.parse_expression`; the cell dies once this
+	evaluates to a value greater than 0).
+	"""
 	cdef Term equation
 	cdef int check_dead(self, double* state, double *params, double time, double volume, double initial_time, double initial_volume):
 		if (<Term> self.equation).volume_evaluate(state,params,volume,time) > 0:
@@ -544,6 +765,70 @@ cdef class GeneralDeathRule(DeathRule):
 
 #A subclass of Bioscrape.Types.Model which contains new cell lineage features
 cdef class LineageModel(Model):
+	"""A `~bioscrape.types.Model` extended with growth, division, death.
+
+	Adds volume dynamics and three kinds of per-cell behavior, each
+	governed by either a `LineageRule` (checked every timestep) or
+	an `Event` (fires stochastically via a `Propensity`, like a
+	reaction):
+
+	- Volume: how a cell's volume changes over time
+	  (`VolumeRule`/`VolumeEvent` subclasses).
+	- Division: when a cell divides into two daughters, and (via a
+	  `~bioscrape.simulator.VolumeSplitter`) how species and volume
+	  are partitioned between them (`DivisionRule`/`DivisionEvent`
+	  subclasses).
+	- Death: when a cell is removed from the simulation
+	  (`DeathRule`/`DeathEvent` subclasses).
+
+	The reliable way to attach this behavior is the
+	`create_volume_rule`/`create_volume_event`,
+	`create_division_rule`/`create_division_event`, and
+	`create_death_rule`/`create_death_event` methods, called after
+	construction (as in every example notebook). Simulate the
+	resulting model with `LineageSSASimulator` or the module-level
+	`py_Simulate*`/`py_Propagate*` functions.
+
+	Parameters
+	----------
+	filename : str, optional
+		Path to a (deprecated) bioscrape XML file to import.
+	species : list of str, default []
+		Species names to add to the model.
+	reactions : list of tuple, default []
+		Reaction tuples; see `~bioscrape.types.Model`.
+	parameters : list of tuple or dict, default []
+		`(name, value)` pairs, or a dict, giving initial parameter
+		values.
+	rules : list of tuple, default []
+		Rule tuples `(rule_type, rule_attributes)`. Volume/division/
+		death rule types are routed to `create_volume_rule`/
+		`create_division_rule`/`create_death_rule`; other types go
+		to the base `~bioscrape.types.Model`. Only recognized when
+		`rule_type` itself contains the word ``'volume'``,
+		``'division'``, or ``'death'`` (e.g.
+		``'linearvolumerule'``, not the short form ``'linear'``),
+		and division rules are not currently usable this way at all
+		(no way to supply a `VolumeSplitter`) -- prefer
+		`create_volume_rule`/`create_division_rule`/
+		`create_death_rule` instead.
+	events : list of tuple, default []
+		Event tuples `(event_type, event_params,
+		event_propensity_type, propensity_params)`. Routed like
+		`rules`, with the same limitations -- prefer
+		`create_volume_event`/`create_division_event`/
+		`create_death_event` instead.
+	sbml_filename : str, optional
+		Path to an SBML file to import.
+	initial_condition_dict : dict, optional
+		Maps species names to initial values.
+	input_printout : bool, default False
+		If True, print verbose status messages while constructing
+		the model.
+	initialize_model : bool, default True
+		If True, validate the model and build its internal arrays
+		after construction.
+	"""
 
 	############################################################################
 	# DEVELOPER WARNING 
@@ -598,6 +883,7 @@ cdef class LineageModel(Model):
 	cdef double global_volume
 
 	def __init__(self, filename = None, species = [], reactions = [], parameters = [], rules = [], events = [], sbml_filename = None, initial_condition_dict = None, input_printout = False, initialize_model = True):
+		"""See class docstring."""
 
 
 		self.volume_events_list = []
@@ -726,17 +1012,71 @@ cdef class LineageModel(Model):
 			self.c_death_events.push_back(<void*>event)
 
 	def py_initialize(self):
+		"""Validate the model and build its internal C-level arrays.
+
+		Called automatically by the constructor unless
+		`initialize_model=False` was passed. See
+		`~bioscrape.types.Model.py_initialize`.
+		"""
 		self._initialize()
 		self.initialized = True
 
 	def py_get_event_counts(self):
+		"""Return the number of division, volume, and death events.
+
+		Returns
+		-------
+		tuple of int
+			`(num_division_events, num_volume_events,
+			num_death_events)`.
+		"""
 		return self.num_division_events, self.num_volume_events, self.num_death_events
 	def py_get_rule_counts(self):
+		"""Return the number of division, volume, and death rules.
+
+		Returns
+		-------
+		tuple of int
+			`(num_division_rules, num_volume_rules,
+			num_death_rules)`.
+		"""
 		return self.num_division_rules, self.num_volume_rules, self.num_death_rules
 
-	def add_event(self, Event event_object, dict event_param_dict, 
-				  Propensity prop_object, dict propensity_param_dict, 
+	def add_event(self, Event event_object, dict event_param_dict,
+				  Propensity prop_object, dict propensity_param_dict,
 				  str event_type = None, VolumeSplitter volume_splitter = None):
+		"""Attach a pre-built `Event` and `Propensity` to the model.
+
+		Lower-level building block used by `create_volume_event`,
+		`create_division_event`, and `create_death_event`; prefer
+		those methods, which also construct the `Event` and
+		`Propensity` objects for you.
+
+		Parameters
+		----------
+		event_object : Event
+			The event to attach.
+		event_param_dict : dict
+			The event's field dictionary (passed to
+			`Event.initialize`).
+		prop_object : Propensity
+			The propensity governing when the event fires.
+		propensity_param_dict : dict
+			The propensity's field dictionary.
+		event_type : str, optional
+			One of ``'division'``, ``'volume'``, or ``'death'``
+			(several capitalizations/suffixes accepted).
+		volume_splitter : VolumeSplitter, optional
+			Required if `event_type` is a division event; used to
+			partition the daughter cells.
+
+		Raises
+		------
+		ValueError
+			If `event_type` is a division event and
+			`volume_splitter` is not given, or if `event_type` is
+			not recognized.
+		"""
 		self.initialized = False
 
 		species_names_e, param_names_e = \
@@ -767,6 +1107,29 @@ cdef class LineageModel(Model):
 			# self.other_events_list.append((event_object, prop_object))
 
 	def create_death_event(self, str event_type, dict event_params, str event_propensity_type, dict propensity_params, print_out = False):
+		"""Create a `DeathEvent` and add it to the model.
+
+		Parameters
+		----------
+		event_type : str
+			Currently only the default type is supported: ``''``,
+			``'death'``, ``'deathevent'``, ``'death event'``, or
+			``'default'``.
+		event_params : dict
+			The event's field dictionary (unused by `DeathEvent`).
+		event_propensity_type : str
+			The propensity type governing when the event fires; see
+			`create_propensity`.
+		propensity_params : dict
+			Parameters for the given propensity type.
+		print_out : bool, default False
+			If True, print the propensity being created.
+
+		Raises
+		------
+		ValueError
+			If `event_type` is not a recognized type.
+		"""
 		event_params = dict(event_params)
 		propensity_params = dict(propensity_params)
 		prop_object = self.create_propensity(event_propensity_type, propensity_params, input_printout = print_out)
@@ -777,6 +1140,32 @@ cdef class LineageModel(Model):
 		self.add_event(event_object, event_params, prop_object, propensity_params, event_type = "death")
 
 	def create_division_event(self, str event_type, dict event_params, str event_propensity_type, dict propensity_params, VolumeSplitter volume_splitter, print_out = False):
+		"""Create a `DivisionEvent` and add it to the model.
+
+		Parameters
+		----------
+		event_type : str
+			Currently only the default type is supported: ``''``,
+			``'division'``, ``'divisionevent'``, ``'division
+			event'``, or ``'default'``.
+		event_params : dict
+			The event's field dictionary (unused by `DivisionEvent`).
+		event_propensity_type : str
+			The propensity type governing when the event fires; see
+			`create_propensity`.
+		propensity_params : dict
+			Parameters for the given propensity type.
+		volume_splitter : VolumeSplitter
+			Used to partition the daughter cells' species and
+			volume.
+		print_out : bool, default False
+			If True, print the event being created.
+
+		Raises
+		------
+		ValueError
+			If `event_type` is not a recognized type.
+		"""
 		if print_out:
 			print("Adding New DivisionEvent with event_type=", event_type, "params=", event_params, "propensity_type=",event_propensity_type, "propensity_params=", propensity_params, "and VolumeSplitter=", volume_splitter)
 		event_params = dict(event_params)
@@ -791,6 +1180,31 @@ cdef class LineageModel(Model):
 		self.add_event(event_object, event_params, prop_object, propensity_params, event_type = "division", volume_splitter = volume_splitter)
 
 	def create_volume_event(self, event_type, dict event_params, str event_propensity_type, dict propensity_params, print_out = False):
+		"""Create a volume-changing `Event` and add it to the model.
+
+		Parameters
+		----------
+		event_type : str
+			One of ``'linear'``, ``'multiplicative'``, or
+			``'general'`` (several capitalizations/suffixes
+			accepted); see `LinearVolumeEvent`,
+			`MultiplicativeVolumeEvent`, `GeneralVolumeEvent` for
+			the corresponding `event_params` keys.
+		event_params : dict
+			The event's field dictionary.
+		event_propensity_type : str
+			The propensity type governing when the event fires; see
+			`create_propensity`.
+		propensity_params : dict
+			Parameters for the given propensity type.
+		print_out : bool, default False
+			If True, warn with the event being created.
+
+		Raises
+		------
+		ValueError
+			If `event_type` is not a recognized type.
+		"""
 		event_params = dict(event_params)
 		propensity_params = dict(propensity_params)
 		if print_out:
@@ -811,6 +1225,34 @@ cdef class LineageModel(Model):
 		self.add_event(event_object, event_params, prop_object, propensity_params, event_type = "volume")
 
 	def add_lineage_rule(self, LineageRule rule_object, dict rule_param_dict, str rule_type, VolumeSplitter volume_splitter = None):
+		"""Attach a pre-built `LineageRule` to the model.
+
+		Lower-level building block used by `create_volume_rule`,
+		`create_division_rule`, and `create_death_rule`; prefer
+		those methods, which also construct the `LineageRule` object
+		for you.
+
+		Parameters
+		----------
+		rule_object : LineageRule
+			The rule to attach.
+		rule_param_dict : dict
+			The rule's field dictionary (passed to
+			`LineageRule.initialize`).
+		rule_type : str
+			Must contain (case-insensitively) ``'division'``,
+			``'death'``, or ``'volume'``.
+		volume_splitter : VolumeSplitter, optional
+			Required if `rule_type` is a division rule; used to
+			partition the daughter cells.
+
+		Raises
+		------
+		ValueError
+			If `rule_type` is a division rule and `volume_splitter`
+			is not given, or if `rule_type` doesn't identify a
+			division, death, or volume rule.
+		"""
 		species_names, param_names = rule_object.get_species_and_parameters(rule_param_dict, self.species2index, self.params2index)
 
 		for species_name in species_names:
@@ -832,6 +1274,24 @@ cdef class LineageModel(Model):
 				raise ValueError("add_lineage_rule only takes rules of type 'DeathRule', 'DivisionRule', and 'VolumeRule'. For Other rule types, consider trying Model.add_rule.")
 
 	def create_death_rule(self, str rule_type, dict rule_param_dict):
+		"""Create a `DeathRule` and add it to the model.
+
+		Parameters
+		----------
+		rule_type : str
+			One of ``'species'``, ``'param'``/``'parameter'``, or
+			``'general'`` (or their `*DeathRule` class-name-style
+			aliases); see `SpeciesDeathRule`, `ParamDeathRule`,
+			`GeneralDeathRule` for the corresponding
+			`rule_param_dict` keys.
+		rule_param_dict : dict
+			The rule's field dictionary.
+
+		Raises
+		------
+		ValueError
+			If `rule_type` is not a recognized type.
+		"""
 		if rule_type.lower() in ["species", "speciesdeathrule"]:
 			self._param_dict_check(rule_param_dict, "specie", "DummyVar_SpeciesDeathRule")
 			self._param_dict_check(rule_param_dict, "threshold", "DummyVar_SpeciesDeathRule")
@@ -852,6 +1312,28 @@ cdef class LineageModel(Model):
 		self.add_lineage_rule(rule_object, rule_param_dict, rule_type = "death")
 
 	def create_division_rule(self, str rule_type, dict rule_param_dict, VolumeSplitter volume_splitter):
+		"""Create a `DivisionRule` and add it to the model.
+
+		Parameters
+		----------
+		rule_type : str
+			One of ``'time'``, ``'volume'``, ``'delta'``/
+			``'deltaV'``, or ``'general'`` (or their
+			`*DivisionRule` class-name-style aliases); see
+			`TimeDivisionRule`, `VolumeDivisionRule`,
+			`DeltaVDivisionRule`, `GeneralDivisionRule` for the
+			corresponding `rule_param_dict` keys.
+		rule_param_dict : dict
+			The rule's field dictionary.
+		volume_splitter : VolumeSplitter
+			Used to partition the daughter cells' species and
+			volume.
+
+		Raises
+		------
+		ValueError
+			If `rule_type` is not a recognized type.
+		"""
 		if rule_type.lower() in ["time", "timedivisionrule"]:
 			self._param_dict_check(rule_param_dict, "threshold", "DummyVar_TimeDeathRule")
 			if "noise" in rule_param_dict:
@@ -874,6 +1356,25 @@ cdef class LineageModel(Model):
 		self.add_lineage_rule(rule_object, rule_param_dict, rule_type = 'division', volume_splitter = volume_splitter)
 
 	def create_volume_rule(self, str rule_type, dict rule_param_dict):
+		"""Create a `VolumeRule` and add it to the model.
+
+		Parameters
+		----------
+		rule_type : str
+			One of ``'linear'``, ``'multiplicative'``,
+			``'assignment'``, or ``'ode'`` (or their `*VolumeRule`
+			class-name-style aliases); see `LinearVolumeRule`,
+			`MultiplicativeVolumeRule`, `AssignmentVolumeRule`,
+			`ODEVolumeRule` for the corresponding `rule_param_dict`
+			keys.
+		rule_param_dict : dict
+			The rule's field dictionary.
+
+		Raises
+		------
+		ValueError
+			If `rule_type` is not a recognized type.
+		"""
 		if rule_type.lower() in ["linear", "linearvolumerule"]:
 			self._param_dict_check(rule_param_dict, "growth_rate", "DummyVar_LinearVolumeRule")
 			if "noise" in rule_param_dict:
@@ -907,20 +1408,32 @@ cdef class LineageModel(Model):
 	cdef list get_lineage_propensities(self):
 		return self.lineage_propensities
 	def py_get_lineage_propensities(self):
+		"""Return the `Propensity` objects backing every event.
+
+		Covers every volume, division, and death event, in the
+		order they were added.
+		"""
 		return self.lineage_propensities
 	def py_get_num_lineage_propensities(self):
+		"""Return the total number of volume/division/death event propensities."""
 		return len(self.lineage_propensities)
 	def py_get_num_division_rules(self):
+		"""Return the number of division rules."""
 		return self.get_num_division_rules()
 	def py_get_num_volume_rules(self):
+		"""Return the number of volume rules."""
 		return self.get_num_volume_rules()
 	def py_get_num_death_rules(self):
+		"""Return the number of death rules."""
 		return self.get_num_death_rules()
 	def py_get_num_division_events(self):
+		"""Return the number of division events."""
 		return self.get_num_division_events()
 	def py_get_num_volume_events(self):
+		"""Return the number of volume events."""
 		return self.get_num_volume_events()
 	def py_get_num_death_events(self):
+		"""Return the number of death events."""
 		return self.get_num_death_events()
 
 	cdef (vector[void*])* get_c_lineage_propensities(self):
@@ -939,6 +1452,15 @@ cdef class LineageModel(Model):
 		return & self.c_death_events
 
 	def py_get_volume_splitters(self):
+		"""Return the `VolumeSplitter` for every division rule and event.
+
+		Returns
+		-------
+		tuple of list of VolumeSplitter
+			`(rule_volume_splitters, event_volume_splitters)`, each
+			in the order the corresponding division rule/event was
+			added.
+		"""
 		return self.rule_volume_splitters, self.event_volume_splitters
 
 	def __getstate__(self):
@@ -1049,6 +1571,17 @@ cdef class LineageModel(Model):
 		self.global_volume = state[21]
 
 cdef class LineageCSimInterface(ModelCSimInterface):
+	"""A `~bioscrape.simulator.ModelCSimInterface` for a `LineageModel`.
+
+	Extracts a `LineageModel`'s volume/division/death rules and
+	events, and their `VolumeSplitter` objects, for use by
+	`LineageSSASimulator`.
+
+	Parameters
+	----------
+	M : LineageModel
+		The model to wrap.
+	"""
 	cdef unsigned num_division_events
 	cdef unsigned num_division_rules
 	cdef unsigned num_death_events
@@ -1074,6 +1607,7 @@ cdef class LineageCSimInterface(ModelCSimInterface):
 	cdef list division_rule_volume_splitters
 
 	def __init__(self, LineageModel M):
+		"""See class docstring."""
 		super().__init__(M)
 		self.num_division_rules = <unsigned>M.py_get_num_division_rules()
 		self.num_volume_rules = <unsigned>M.py_get_num_volume_rules()
@@ -1176,6 +1710,22 @@ cdef class LineageCSimInterface(ModelCSimInterface):
 
 #A safe-mode CSimInterface for Lineages
 cdef class SafeLineageCSimInterface(LineageCSimInterface):
+	"""A `LineageCSimInterface` with extra validity checks.
+
+	See `~bioscrape.simulator.SafeModelCSimInterface`, which this
+	mirrors: warns (and zeroes out) negative propensities, and warns
+	if a species count or volume falls outside
+	``[0, max_species_count]``/``(0, max_volume]``.
+
+	Parameters
+	----------
+	external_model : LineageModel
+		The model to wrap.
+	max_volume : float, default 10000
+		Upper bound on volume before a warning is issued.
+	max_species_count : float, default 10000
+		Upper bound on a species count before a warning is issued.
+	"""
 	cdef unsigned rxn_ind
 	cdef unsigned s_ind
 	cdef unsigned prop_is_0
@@ -1184,6 +1734,7 @@ cdef class SafeLineageCSimInterface(LineageCSimInterface):
 	cdef double max_volume
 
 	def __init__(self, external_model, max_volume = 10000, max_species_count = 10000):
+		"""See class docstring."""
 		self.max_volume = max_volume
 		self.max_species_count = max_species_count
 		super().__init__(external_model)
@@ -1254,6 +1805,45 @@ cdef class SafeLineageCSimInterface(LineageCSimInterface):
 
 #A new wrapper for the VolumeCellState with new internal variables
 cdef class LineageVolumeCellState(DelayVolumeCellState):
+	"""A cell state for lineage simulation: species, time, volume, birth.
+
+	Extends `~bioscrape.simulator.DelayVolumeCellState` with the
+	cell's birth time/volume and whether/why it has divided or died.
+
+	Parameters
+	----------
+	v0 : float, default 0
+		The cell's volume at birth.
+	t0 : float, default 0
+		The cell's birth time.
+	state : array-like, default []
+		The species values.
+	volume : float, optional
+		The cell's current volume. Defaults to `v0`.
+	time : float, optional
+		The cell's current time. Defaults to `t0`.
+	divided : int, default -1
+		Whether/why the cell has divided; see the `divided`
+		attribute.
+	dead : int, default -1
+		Whether/why the cell has died; see the `dead` attribute.
+
+	Attributes
+	----------
+	divided : int
+		-1 if the cell has not divided. If in
+		``[0, num_division_rules)``, the index of the `DivisionRule`
+		that caused division. If in ``[num_division_rules,
+		num_division_rules + num_division_events)``, the index
+		(offset by `num_division_rules`) of the `DivisionEvent` that
+		caused division.
+	dead : int
+		-1 if the cell has not died. If in ``[0, num_death_rules)``,
+		the index of the `DeathRule` that caused death. If in
+		``[num_death_rules, num_death_rules +
+		num_death_events)``, the index (offset by `num_death_rules`)
+		of the `DeathEvent` that caused death.
+	"""
 	cdef double initial_volume #Stores the birth Volume
 	cdef double initial_time #Stores the time the Cell was "born"
 	#divided = -1: Cell Not divided
@@ -1267,6 +1857,7 @@ cdef class LineageVolumeCellState(DelayVolumeCellState):
 	cdef state_set
 
 	def __init__(self, v0 = 0, t0 = 0, state = [], volume = None, time = None, divided = -1, dead = -1):
+		"""See class docstring."""
 		self.set_initial_vars(v0, t0)
 		if volume is not None:
 			self.set_volume(volume)
@@ -1286,9 +1877,17 @@ cdef class LineageVolumeCellState(DelayVolumeCellState):
 			self.py_set_state(state)
 
 	def get_state_set(self):
+		"""Return whether the species state has been explicitly set."""
 		return self.state_set
 
 	def py_set_state(self, state):
+		"""Set the species values.
+
+		Parameters
+		----------
+		state : array-like
+			The species values.
+		"""
 		self.state_set = 1
 		return super().py_set_state(np.asarray(state))
 
@@ -1306,12 +1905,14 @@ cdef class LineageVolumeCellState(DelayVolumeCellState):
 		return self.state[comp_ind]
 
 	def py_get_initial_volume(self):
+		"""Return the cell's volume at birth."""
 		return self.get_initial_volume()
 
 	cdef double get_initial_time(self):
 		return self.initial_time
 
 	def py_get_initial_time(self):
+		"""Return the cell's birth time."""
 		return self.get_initial_time()
 
 	cdef void set_divided(self, divided):
@@ -1341,6 +1942,30 @@ cdef class LineageVolumeCellState(DelayVolumeCellState):
 		return (self.__class__, (self.initial_volume, self.initial_time, self.state, self.volume, self.time, self.divided, self.dead))
 
 cdef class SingleCellSSAResult(VolumeSSAResult):
+	"""The result of simulating a single cell up to division/death.
+
+	Extends `~bioscrape.simulator.VolumeSSAResult` with whether/why
+	the cell divided or died, and (optionally) its initial time and
+	volume. `divided`/`dead` and the initial time/volume are not set
+	by the constructor -- use `py_set_divided`/`py_set_dead`/
+	`py_set_initial_time`/`py_set_initial_volume`.
+
+	Attributes
+	----------
+	divided : int
+		-1 if the cell has not divided. If in
+		``[0, num_division_rules)``, the index of the `DivisionRule`
+		that caused division. If in ``[num_division_rules,
+		num_division_rules + num_division_events)``, the index
+		(offset by `num_division_rules`) of the `DivisionEvent` that
+		caused division.
+	dead : int
+		-1 if the cell has not died. If in ``[0, num_death_rules)``,
+		the index of the `DeathRule` that caused death. If in
+		``[num_death_rules, num_death_rules +
+		num_death_events)``, the index (offset by `num_death_rules`)
+		of the `DeathEvent` that caused death.
+	"""
 	#divided = -1: Cell Not divided
 	#divided E [0, num_division_rules): DivisionRule divided caused the cell to divide
 	#divided E [num_division_rules, num_division_rules + num_division_events]: Division Event divided-num_division_rules caused the cell to divide
@@ -1358,31 +1983,37 @@ cdef class SingleCellSSAResult(VolumeSSAResult):
 	cdef void set_dead(self, int dead):
 		self.dead = dead
 	def py_set_dead(self, dead):
+		"""Set the `dead` attribute; see the class docstring."""
 		self.set_dead(dead)
 
 	cdef int get_dead(self):
 		return self.dead
 	def py_get_dead(self):
+		"""Return the `dead` attribute; see the class docstring."""
 		return self.get_dead()
 
 	cdef void set_divided(self, int divided):
 		self.divided = divided
 	def py_set_divided(self, divided):
+		"""Set the `divided` attribute; see the class docstring."""
 		self.set_divided(divided)
 
 	cdef int get_divided(self):
 		return self.divided
 	def py_get_divided(self):
+		"""Return the `divided` attribute; see the class docstring."""
 		return self.get_divided()
 
 	cdef void set_initial_time(self, double t):
 		self.t0 = t
 	def py_set_initial_time(self, t):
+		"""Set the cell's initial (birth) time."""
 		self.set_initial_time(t)
 
 	cdef void set_initial_volume(self, double v):
 		self.v0 = v
 	def py_set_initial_volume(self, v):
+		"""Set the cell's initial (birth) volume."""
 		self.set_initial_volume(v)
 
 	cdef VolumeCellState get_final_cell_state(self):
@@ -1405,6 +2036,33 @@ cdef class SingleCellSSAResult(VolumeSSAResult):
 
 
 cdef class LineageVolumeSplitter(VolumeSplitter):
+	"""Splits a cell's volume and species between two daughter cells.
+
+	Each species (and the volume itself) can be partitioned
+	independently: ``'binomial'`` (each molecule independently goes
+	to one daughter with probability ~0.5), ``'perfect'``
+	(proportional to volume, +/- 1 for rounding), ``'duplicate'``
+	(both daughters get the parent's full count), or a named entry
+	in `custom_partition_functions`.
+
+	Parameters
+	----------
+	M : Model
+		The model whose species are being partitioned.
+	options : dict, default {}
+		Maps a species name (or the special keys ``'default'`` and
+		``'volume'``) to its partitioning mode: ``'binomial'``,
+		``'perfect'``, ``'duplicate'``, or a key in
+		`custom_partition_functions`. Species not listed use the
+		``'default'`` entry's mode (``'binomial'`` if not given);
+		``'volume'`` defaults to the same mode as ``'default'``.
+	custom_partition_functions : dict, optional
+		Maps a name to a callable used when that name is given as a
+		partitioning mode in `options`.
+	partition_noise : float, default 0.5
+		Extra randomness in the binomial split fraction; must be
+		between 0 and 1.
+	"""
 	cdef unsigned how_to_split_v
 	cdef unsigned how_to_split_default
 	cdef vector[int] binomial_indices
@@ -1416,6 +2074,7 @@ cdef class LineageVolumeSplitter(VolumeSplitter):
 	cdef dict custom_partition_functions
 
 	def __init__(self, Model M, options = {}, custom_partition_functions = {}, partition_noise = .5):
+		"""See class docstring."""
 		self.ind2customsplitter == {}
 		self.custom_partition_functions = custom_partition_functions
 		if self.partition_noise > 1:
@@ -1559,21 +2218,28 @@ cdef class LineageVolumeSplitter(VolumeSplitter):
 		return ans
 
 cdef class CappedStateQueue():
-	'''
-	Implements a minimum priority queue for LineageVolumeCellStates, sorted by
-	time, so pop_event() always returns the LineageVolumeCellState with the lowest
-	time. 
+	"""A size-capped min-priority queue of `LineageVolumeCellState`.
 
-	Additionally, CappedStateQueues have a maximum size, set by pop_cap. If the 
-	queue is full and another event is added, then after adding the new one, a random one
-	will be removed from the queue, and the heap restored.
-	'''
+	A minimum priority queue (binary heap) sorted by time, so
+	`py_pop_event` always returns the `LineageVolumeCellState` with
+	the lowest time.
+
+	Has a maximum size, `pop_cap`. If the queue is full and another
+	event is added, a random element is then removed and the heap
+	restored, keeping the queue at or under `pop_cap`.
+
+	Parameters
+	----------
+	pop_cap : int
+		The maximum queue size.
+	"""
 	cdef list queue_array # <-- think more about this name! Confusing that array != list
 	cdef unsigned int pop_cap
 	cdef unsigned int pop_size
 	cdef LineageVolumeCellState s1, s2, s3
 
 	def __init__(self, pop_cap):
+		"""See class docstring."""
 		self.pop_cap  = pop_cap
 		self.pop_size = 0
 		self.queue_array = [None] * (pop_cap+1)
@@ -1593,9 +2259,23 @@ cdef class CappedStateQueue():
 		self.pop_size = len(new_array)
 
 	def py_get_underlying_array(self):
+		"""Return the queue's backing array (heap order, not sorted)."""
 		return self.get_underlying_array()
 
 	def py_set_underlying_array(self, new_array):
+		"""Replace the queue's contents with a pre-built heap array.
+
+		Parameters
+		----------
+		new_array : list of LineageVolumeCellState
+			The new backing array; must already satisfy the min-heap
+			property, and have at most `pop_cap` elements.
+
+		Raises
+		------
+		ValueError
+			If `new_array` is longer than `pop_cap`.
+		"""
 		self.set_underlying_array(new_array)
 
 	cdef void push_event(self, LineageVolumeCellState new_event):	
@@ -1633,9 +2313,20 @@ cdef class CappedStateQueue():
 		return self.s1
 
 	def py_pop_event(self):
+		"""Remove and return the earliest-time `LineageVolumeCellState`."""
 		return self.pop_event()
 
 	def py_push_event(self, new_event):
+		"""Add a `LineageVolumeCellState` to the queue.
+
+		If this leaves the queue over `pop_cap`, a random element is
+		then removed.
+
+		Parameters
+		----------
+		new_event : LineageVolumeCellState
+			The cell state to add.
+		"""
 		self.push_event(new_event)
 
 	cdef void rebuild_from_position_up(self, unsigned int i):
@@ -1676,11 +2367,16 @@ cdef class CappedStateQueue():
 		return self.pop_size == 0
 
 	def is_still_heap(self):
-		'''
-		Checks that the underlying array's minimum heap property is still valid.
-		Iterates through each non-leaf node and checks that each child has larger
-		time. 
-		'''
+		"""Check that the backing array still satisfies the min-heap property.
+
+		Iterates through each non-leaf node and checks that each
+		child has a later (or equal) time.
+
+		Returns
+		-------
+		bool
+			True if the min-heap property holds.
+		"""
 		cdef unsigned int i, j
 		if self.pop_size <= 1:
 			return True
@@ -1702,6 +2398,18 @@ cdef class CappedStateQueue():
 
 
 cdef class LineageSSASimulator:
+	"""A stochastic simulator for `LineageModel` cell lineages.
+
+	Implements the core per-cell SSA -- checking division/death
+	rules and events, applying volume rules, and resolving
+	reaction/event propensities -- used by the module-level
+	`py_SimulateSingleCell`, `py_SimulateCellLineage`,
+	`py_SingleCellLineage`, `py_PropagateCells`, and
+	`py_SimulateTurbidostat` functions. Not normally constructed
+	with arguments directly; use those module-level functions, which
+	build the required `LineageCSimInterface` and initial cell
+	states for you.
+	"""
 	#Memory Views are reused between each individual cell
 	#Sometimes, to be compatable with the double* used in original bioscrape, these are cast to double*
 	#these are used by SimulateSingleCell
@@ -1734,6 +2442,19 @@ cdef class LineageSSASimulator:
 
 	#Python accessible version
 	def py_create_propensity_buffer(self, LineageCSimInterface interface):
+		"""Return a zeroed propensity buffer sized for `interface`.
+
+		Parameters
+		----------
+		interface : LineageCSimInterface
+			The interface to size the buffer for (covers reactions
+			plus volume/division/death event propensities).
+
+		Returns
+		-------
+		numpy.ndarray
+			The zeroed buffer.
+		"""
 		return self.create_propensity_buffer(interface)
 
 	#helper function to take an np.ndarrays and set them to internal memory views
@@ -1741,12 +2462,20 @@ cdef class LineageSSASimulator:
 		self.c_truncated_timepoints = timepoints
 	#python accessible version
 	def py_set_c_truncated_timepoints(self, np.ndarray timepoints):
+		"""Set the internal truncated-timepoints buffer.
+
+		Advanced/internal use; typically not called directly.
+		"""
 		self.set_c_truncated_timepoints(timepoints)
 
 	cdef void set_c_timepoints(self, np.ndarray timepoints):
 		self.c_timepoints = timepoints
 	#Python accessible version
 	def py_set_c_timepoints(self, np.ndarray timepoints):
+		"""Set the internal timepoints buffer.
+
+		Advanced/internal use; typically not called directly.
+		"""
 		self.set_c_timepoints(timepoints)
 
 	#Sets the internal interface and associated internal variables
@@ -1779,15 +2508,27 @@ cdef class LineageSSASimulator:
 		self.c_current_state = np.zeros(self.num_species)
 
 	def py_initialize_single_cell_interface(self, LineageCSimInterface interface):
+		"""Set the interface to simulate and reset internal buffers.
+
+		Must be called before simulating with a given `interface`
+		via the lower-level `cdef` methods. The module-level
+		`py_Simulate*`/`py_Propagate*` functions call this for you.
+		Advanced/internal use; typically not called directly.
+
+		Parameters
+		----------
+		interface : LineageCSimInterface
+			The interface to simulate.
+		"""
 		self.initialize_single_cell_interface(interface)
 
 	#Allocates buffer to store results from SimulateSingleCell
 	cdef void initialize_single_cell_results_arrays(self, unsigned num_timepoints):
-		cdef np.ndarray[np.double_t,ndim=2] results 
+		cdef np.ndarray[np.double_t,ndim=2] results
 		cdef np.ndarray[np.double_t,ndim=1] volume_trace
 
 		if num_timepoints == 0:
-			num_timepoints = 1 
+			num_timepoints = 1
 		results = np.zeros((num_timepoints,self.num_species))
 		self.c_results = results
 		volume_trace = np.zeros(num_timepoints,)
@@ -1795,6 +2536,15 @@ cdef class LineageSSASimulator:
 
 	#python accessible version
 	def py_initialize_single_cell_results_arrays(self, int num_timepoints):
+		"""Allocate the result buffers for a single-cell simulation.
+
+		Advanced/internal use; typically not called directly.
+
+		Parameters
+		----------
+		num_timepoints : int
+			The number of timepoints to allocate room for.
+		"""
 		self.initialize_single_cell_results_arrays(num_timepoints)
 
 	#SSA for a single cell. Simulates until it divides or dies using division / death rules and/or reactions.
@@ -2073,7 +2823,37 @@ cdef class LineageSSASimulator:
 		return SCR
 
 	def py_SimulateSingleCell(self, np.ndarray timepoints, LineageModel Model = None, LineageCSimInterface interface = None, LineageVolumeCellState v = None, safe = False):
+		"""Simulate one cell until it divides, dies, or time runs out.
 
+		Lower-level than the module-level `py_SimulateSingleCell`;
+		prefer that function unless reusing this simulator across
+		many calls for performance.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to report simulation results at.
+		Model : LineageModel, optional
+			The model to simulate. Exactly one of `Model` or
+			`interface` must be given.
+		interface : LineageCSimInterface, optional
+			A specific simulation interface to use instead of
+			building one from `Model`. Exactly one of `Model` or
+			`interface` must be given.
+		v : LineageVolumeCellState, optional
+			The starting cell state. Defaults to the model's initial
+			state, with volume 1 and time 0.
+		safe : bool, default False
+			If True and `interface` is not given, build a
+			`SafeLineageCSimInterface` instead of a
+			`LineageCSimInterface`.
+
+		Returns
+		-------
+		SingleCellSSAResult
+			The single cell's trajectory, up to its division, death,
+			or the final timepoint.
+		"""
 		if Model == None and interface == None:
 			raise ValueError('py_SimulateSingleCell requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
 		elif interface == None:
@@ -2260,6 +3040,26 @@ cdef class LineageSSASimulator:
 
 	#Python wrapper of the above
 	def py_SimulateCellLineage(self, np.ndarray timepoints, initial_cell_states, LineageCSimInterface interface):
+		"""Simulate a full lineage of growing, dividing, and dying cells.
+
+		Lower-level than the module-level `py_SimulateCellLineage`;
+		prefer that function unless reusing this simulator across
+		many calls for performance.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to simulate over.
+		initial_cell_states : list of LineageVolumeCellState
+			The starting cells.
+		interface : LineageCSimInterface
+			The simulation interface to use.
+
+		Returns
+		-------
+		Lineage
+			The full simulated lineage tree.
+		"""
 		#Instantiate variables
 		self.lineage = Lineage()
 		self.old_cell_states = []
@@ -2477,6 +3277,36 @@ cdef class LineageSSASimulator:
 
 	#Python wrapper of SimulateTurbidostat
 	def py_SimulateTurbidostat(self, list initial_cell_states, np.ndarray timepoints, np.ndarray sample_times, unsigned int population_cap, LineageCSimInterface interface, bool debug = False):
+		"""Simulate a cell population capped at a maximum size.
+
+		Lower-level than the module-level `py_SimulateTurbidostat`;
+		prefer that function unless reusing this simulator across
+		many calls for performance.
+
+		Parameters
+		----------
+		initial_cell_states : list of LineageVolumeCellState
+			The starting cells.
+		timepoints : numpy.ndarray
+			The times to simulate over.
+		sample_times : numpy.ndarray
+			Times at which to sample (and downsample) the
+			population.
+		population_cap : int
+			The maximum population size to maintain at each sample
+			time.
+		interface : LineageCSimInterface
+			The simulation interface to use.
+		debug : bool, default False
+			If True, print verbose status messages during
+			simulation.
+
+		Returns
+		-------
+		list
+			One entry per sample time: a list of
+			`LineageVolumeCellState`.
+		"""
 		self.cell_states = []
 		self.set_c_timepoints(timepoints)
 		self.intialize_single_cell_interface(interface)
@@ -2485,6 +3315,33 @@ cdef class LineageSSASimulator:
 
 	#Python wrapper of the above
 	def py_PropagateCells(self, np.ndarray timepoints, list initial_cell_states, LineageCSimInterface interface, np.ndarray sample_times, unsigned include_dead_cells):
+		"""Simulate a population of cells, returning periodic snapshots.
+
+		Lower-level than the module-level `py_PropagateCells`;
+		prefer that function unless reusing this simulator across
+		many calls for performance.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to simulate over.
+		initial_cell_states : list of LineageVolumeCellState
+			The starting cells.
+		interface : LineageCSimInterface
+			The simulation interface to use.
+		sample_times : numpy.ndarray
+			Times at which to sample the population; must be a
+			subset of `timepoints`.
+		include_dead_cells : unsigned
+			If nonzero, dead cells accumulated along the way are
+			included in the returned samples.
+
+		Returns
+		-------
+		list
+			One entry per sample time: a list of
+			`LineageVolumeCellState`.
+		"""
 		self.cell_states = []
 		self.old_cell_states = []
 		self.set_c_timepoints(timepoints)
@@ -2540,6 +3397,27 @@ cdef class LineageSSASimulator:
 		return self.cell_states
 	#Python wrapper of the above
 	def py_SingleCellLineage(self, np.ndarray timepoints, LineageVolumeCellState initial_cell, LineageCSimInterface interface):
+		"""Track a single continuous-time cell lineage trace.
+
+		Lower-level than the module-level `py_SingleCellLineage`;
+		prefer that function unless reusing this simulator across
+		many calls for performance.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to report simulation results at.
+		initial_cell : LineageVolumeCellState
+			The starting cell state.
+		interface : LineageCSimInterface
+			The simulation interface to use.
+
+		Returns
+		-------
+		list of SingleCellSSAResult
+			The single cell's trajectory segments, one per division,
+			up to its death or the final timepoint.
+		"""
 		self.set_c_timepoints(timepoints)
 		self.intialize_single_cell_interface(interface)
 		return self.SingleCellLineage(initial_cell, timepoints)
@@ -2549,6 +3427,44 @@ cdef class LineageSSASimulator:
 
 #SingleCellLineage simulates the trajectory of a single cell, randomly discarding one of its daughters every division.
 def py_SingleCellLineage(timepoints, initial_cell_state = None, LineageModel Model = None, LineageCSimInterface interface = None, LineageSSASimulator simulator = None, return_dataframes = True, safe = False):
+	"""Track a single continuous-time cell lineage trace.
+
+	Simulates one cell; at each division, one daughter is chosen at
+	random and kept, the other is discarded. This produces a single
+	continuous time-course rather than a full lineage tree, which is
+	more efficient than `py_SimulateCellLineage` when only one
+	trace is needed.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to report simulation results at.
+	initial_cell_state : LineageVolumeCellState, optional
+		The starting cell state. Defaults to the model's initial
+		state, with volume 1 and time 0.
+	Model : LineageModel, optional
+		The model to simulate. Exactly one of `Model` or `interface`
+		must be given.
+	interface : LineageCSimInterface, optional
+		A specific simulation interface to use instead of building
+		one from `Model`. Exactly one of `Model` or `interface` must
+		be given.
+	simulator : LineageSSASimulator, optional
+		The simulator to use. Defaults to a new `LineageSSASimulator`.
+	return_dataframes : bool, default True
+		If True, return a `pandas.DataFrame`. If False (or if pandas
+		is not installed), return the raw list of simulation results.
+	safe : bool, default False
+		If True and `interface` is not given, build a
+		`SafeLineageCSimInterface` instead of a `LineageCSimInterface`.
+
+	Returns
+	-------
+	pandas.DataFrame or list
+		The single-cell trace, concatenated across every division,
+		as a DataFrame if `return_dataframes` is True (and pandas is
+		installed), otherwise the raw list of per-segment results.
+	"""
 	if Model == None and interface == None:
 		raise ValueError('py_SingleCellLineage requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
 	elif interface == None:
@@ -2577,13 +3493,61 @@ def py_SingleCellLineage(timepoints, initial_cell_state = None, LineageModel Mod
 	else:
 		return result
 
-#py_PropagateCells simulates an ensemble of growing dividing cells, returning only the cell states at the end of timepoints
-#include_dead_cells toggles whether all dead cells accumulated along the way will also be returned.
-#return data_frames returns all the results as a pandas dataframe. Otherwise results are returned as a list of LineageVolumeCellStates
-def  py_PropagateCells(timepoints, initial_cell_states = [], LineageModel Model = None, 
-	LineageCSimInterface interface = None, LineageSSASimulator simulator = None, 
+def  py_PropagateCells(timepoints, initial_cell_states = [], LineageModel Model = None,
+	LineageCSimInterface interface = None, LineageSSASimulator simulator = None,
 	sample_times = 1, include_dead_cells = False, return_dataframes = True, return_sample_times = True, safe = False):
+	"""Simulate a population of cells, returning periodic snapshots.
 
+	Propagates an ensemble of cells (growing, dividing, and
+	optionally dying), sampling the population's cell states at
+	`sample_times` rather than storing full time-course trajectories
+	-- more memory-efficient than `py_SimulateCellLineage` when only
+	snapshots are needed.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to simulate over.
+	initial_cell_states : list of LineageVolumeCellState or int, default []
+		The starting cells. An int gives that many copies of the
+		model's initial state; an empty list defaults to a single
+		copy of the model's initial state.
+	Model : LineageModel, optional
+		The model to simulate. Exactly one of `Model` or `interface`
+		must be given.
+	interface : LineageCSimInterface, optional
+		A specific simulation interface to use instead of building
+		one from `Model`. Exactly one of `Model` or `interface` must
+		be given.
+	simulator : LineageSSASimulator, optional
+		The simulator to use. Defaults to a new `LineageSSASimulator`.
+	sample_times : int or array-like, default 1
+		Times at which to sample the population. An int gives that
+		many evenly-spaced sample points ending at `timepoints[-1]`.
+	include_dead_cells : bool, default False
+		If True, dead cells accumulated along the way are included
+		in the returned samples, not just cells alive at each sample
+		time.
+	return_dataframes : bool, default True
+		If True (and pandas is installed), return each sample as a
+		`pandas.DataFrame`. If False, return each sample as a list
+		of `LineageVolumeCellState`.
+	return_sample_times : bool, default True
+		If True, also return the actual `sample_times` used.
+	safe : bool, default False
+		If True and `interface` is not given, build a
+		`SafeLineageCSimInterface` instead of a `LineageCSimInterface`.
+
+	Returns
+	-------
+	samples : list
+		One entry per sample time: a DataFrame of cell states (each
+		row a cell, columns are species plus `'volume'`) if
+		`return_dataframes` is True, otherwise a list of
+		`LineageVolumeCellState`.
+	sample_times : numpy.ndarray
+		Only returned if `return_sample_times` is True.
+	"""
 	if Model == None and interface == None:
 		raise ValueError('py_PropagateCells requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
 	elif interface == None:
@@ -2635,10 +3599,39 @@ def  py_PropagateCells(timepoints, initial_cell_states = [], LineageModel Model 
 	else:
 		return return_data
 
-#SimulateCellLineage simulates a lineage of growing, dividing, and dieing cells over timepoints.
-#The entire time trajectory of the simulation is returned as a Lineage which contains a binary tree of Schnitzes each containing a LineageSingleCellSSAResult.
 def py_SimulateCellLineage(timepoints, initial_cell_states = [], initial_cell_count = 1, interface = None, Model = None, safe = False):
+	"""Simulate a full lineage of growing, dividing, and dying cells.
 
+	Unlike `py_PropagateCells`, the entire time trajectory is kept:
+	the result is a `~bioscrape.types.Lineage` containing a binary
+	tree of `~bioscrape.types.Schnitz` objects (one per cell, from
+	its birth/start to its division or death), each holding a
+	`SingleCellSSAResult`.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to simulate over.
+	initial_cell_states : list of LineageVolumeCellState or int, default []
+		The starting cells. An int gives that many copies of the
+		model's initial state; an empty list defaults to a single
+		copy of the model's initial state.
+	interface : LineageCSimInterface, optional
+		A specific simulation interface to use instead of building
+		one from `Model`. Exactly one of `Model` or `interface` must
+		be given.
+	Model : LineageModel, optional
+		The model to simulate. Exactly one of `Model` or `interface`
+		must be given.
+	safe : bool, default False
+		If True and `interface` is not given, build a
+		`SafeLineageCSimInterface` instead of a `LineageCSimInterface`.
+
+	Returns
+	-------
+	Lineage
+		The full simulated lineage tree.
+	"""
 	simulator = LineageSSASimulator()
 	if Model == None and interface == None:
 		raise ValueError('py_SimulateCellLineage requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
@@ -2659,8 +3652,36 @@ def py_SimulateCellLineage(timepoints, initial_cell_states = [], initial_cell_co
 	return simulator.py_SimulateCellLineage(timepoints, interface = interface, initial_cell_states = initial_cell_states)
 
 
-#SimulateSingleCell performs an SSA simulation on a single cell until it divides, dies, or the final timepoint arrives.
 def py_SimulateSingleCell(timepoints, Model = None, interface = None, initial_cell_state = None, return_dataframes = True, safe = False):
+	"""Simulate one cell until it divides, dies, or time runs out.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to report simulation results at.
+	Model : LineageModel, optional
+		The model to simulate. Exactly one of `Model` or `interface`
+		must be given.
+	interface : LineageCSimInterface, optional
+		A specific simulation interface to use instead of building
+		one from `Model`. Exactly one of `Model` or `interface` must
+		be given.
+	initial_cell_state : LineageVolumeCellState, optional
+		The starting cell state. Defaults to the model's initial
+		state, with volume 1 and time 0.
+	return_dataframes : bool, default True
+		If True, return a `pandas.DataFrame`. If False, return the
+		raw simulation result object.
+	safe : bool, default False
+		If True and `interface` is not given, build a
+		`SafeLineageCSimInterface` instead of a `LineageCSimInterface`.
+
+	Returns
+	-------
+	pandas.DataFrame or SingleCellSSAResult
+		The single cell's trajectory, up to its division, death, or
+		the final timepoint.
+	"""
 	simulator = LineageSSASimulator()
 	if Model == None and interface == None:
 		raise ValueError('py_SimulateSingleCell requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
@@ -2681,9 +3702,57 @@ def py_SimulateSingleCell(timepoints, Model = None, interface = None, initial_ce
 	else:
 		return result
 
-#Python class-free wrapper of LinageSSASimulator' SimulateTurbidostat function.
-def py_SimulateTurbidostat(initial_cell_states, timepoints, sample_times, population_cap, 
+def py_SimulateTurbidostat(initial_cell_states, timepoints, sample_times, population_cap,
 	Model = None, interface = None, debug = False, safe = False, return_dataframes = True, return_sample_times = True):
+	"""Simulate a cell population capped at a maximum size.
+
+	Like `py_PropagateCells`, but the population is downsampled at
+	each entry of `sample_times` to stay at or below
+	`population_cap`, making this more efficient for simulating
+	long-running, large populations.
+
+	Parameters
+	----------
+	initial_cell_states : list of LineageVolumeCellState or int
+		The starting cells. An int gives that many copies of the
+		model's initial state.
+	timepoints : numpy.ndarray
+		The times to simulate over.
+	sample_times : int or array-like
+		Times at which to sample (and downsample) the population. An
+		int gives that many evenly-spaced sample points ending at
+		`timepoints[-1]`.
+	population_cap : int
+		The maximum population size to maintain at each sample time.
+	Model : LineageModel, optional
+		The model to simulate. Exactly one of `Model` or `interface`
+		must be given.
+	interface : LineageCSimInterface, optional
+		A specific simulation interface to use instead of building
+		one from `Model`. Exactly one of `Model` or `interface` must
+		be given.
+	debug : bool, default False
+		If True, print verbose status messages during simulation.
+	safe : bool, default False
+		If True and `interface` is not given, build a
+		`SafeLineageCSimInterface` instead of a `LineageCSimInterface`.
+	return_dataframes : bool, default True
+		If True (and pandas is installed), return each sample as a
+		`pandas.DataFrame`. If False, return each sample as a list
+		of `LineageVolumeCellState`.
+	return_sample_times : bool, default True
+		If True, also return the actual `sample_times` used.
+
+	Returns
+	-------
+	samples : list
+		One entry per sample time: a DataFrame of cell states (each
+		row a cell, columns are species plus `'volume'`) if
+		`return_dataframes` is True, otherwise a list of
+		`LineageVolumeCellState`.
+	sample_times : numpy.ndarray
+		Only returned if `return_sample_times` is True.
+	"""
 	simulator = LineageSSASimulator()
 	if Model == None and interface == None:
 		raise ValueError('py_SimulateTurbidostat requires either a LineageModel Model or a LineageCSimInterface interface to be passed in as keyword parameters.')
@@ -2737,6 +3806,19 @@ def py_SimulateTurbidostat(initial_cell_states, timepoints, sample_times, popula
 
 #A simulator class for interacting cell lineages
 cdef class InteractingLineageSSASimulator(LineageSSASimulator):
+	"""A stochastic simulator for interacting `LineageModel` populations.
+
+	Extends `LineageSSASimulator` to one or more cell types that
+	exchange species through a shared extracellular environment,
+	resynchronized periodically. Used by the module-level
+	`py_SimulateInteractingCellLineage` and
+	`py_PropagateInteractingCells` functions, which build the
+	required interfaces for you.
+
+	Warnings
+	--------
+	Interacting-lineage simulation is experimental/beta functionality.
+	"""
 
 	#Used for Simulating Interacting lineages
 	cdef int spec_ind, global_crn_initialized
@@ -2762,9 +3844,18 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 	cdef VolumeSSAResult global_crn_result, period_global_crn_result
 
 	def __init__(self):
+		"""See class docstring."""
 		self.global_crn_initialized = 0
 
 	def get_global_species_array(self):
+		"""Return the global species' values over time.
+
+		Returns
+		-------
+		numpy.ndarray
+			The global species array, or an empty array (with a
+			warning) if no simulation has been run yet.
+		"""
 		#print("get_global_species_array")
 		if self.c_global_species_array is None:
 			warnings.warn("Global Species Array has not been created. Perhaps a simulation hasn't been run yet? Returning empty array.")
@@ -2773,6 +3864,17 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 			return np.asarray(self.c_global_species_array)
 
 	def get_global_crn_results(self):
+		"""Return the shared-environment CRN's simulation result.
+
+		Only meaningful if `setup_global_volume_simulation` was used
+		(i.e. a `global_volume_model` was given).
+
+		Returns
+		-------
+		VolumeSSAResult or None
+			The result, or None (with a warning) if no global CRN
+			simulation was performed.
+		"""
 		#print("get_global_crn_results")
 		if self.global_crn_initialized == 0 or self.global_crn_result == None:
 			warnings.warn("No Global simulation was performed. Will return None.")
@@ -2781,6 +3883,17 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 			return self.global_crn_result
 
 	def get_lineage_list(self):
+		"""Return the simulated lineages, one per cell type.
+
+		Only set after `py_SimulateInteractingCellLineage`.
+
+		Returns
+		-------
+		list of Lineage or None
+			The lineages, or None (with a warning) if the most
+			recent simulation was a `py_PropagateInteractingCells`
+			call instead (see `get_samples`).
+		"""
 		if self.lineage_list is not None:
 			return self.lineage_list
 		else:
@@ -2788,6 +3901,18 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 			return None
 
 	def get_samples(self):
+		"""Return the population snapshots, one per cell type.
+
+		Only set after `py_PropagateInteractingCells`.
+
+		Returns
+		-------
+		tuple of (list, numpy.ndarray) or None
+			`(samples, sample_times)`, or None (with a warning) if
+			the most recent simulation was a
+			`py_SimulateInteractingCellLineage` call instead (see
+			`get_lineage_list`).
+		"""
 		if self.samples is not None:
 			return self.samples, self.sample_times
 		else:
@@ -2796,6 +3921,28 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 
 	#Functions to set up Global simulation
 	def setup_global_volume_simulation(self, simulator, interface, global_species_global_crn_inds):
+		"""Configure a CRN simulating reactions in the shared environment.
+
+		Called internally by `py_set_up_InteractingLineage` when a
+		`global_volume_model` is given; not normally called
+		directly.
+
+		Parameters
+		----------
+		simulator : VolumeSSASimulator or DeterministicSimulator
+			The simulator to use for the shared-environment CRN.
+		interface : ModelCSimInterface
+			The interface for the shared-environment CRN.
+		global_species_global_crn_inds : numpy.ndarray
+			Maps each global species to its species index in
+			`interface`.
+
+		Raises
+		------
+		ValueError
+			If `simulator` or `interface` is not one of the
+			expected types.
+		"""
 		cdef np.ndarray results
 		cdef np.ndarray time = np.zeros(1)
 		cdef np.ndarray volume = np.zeros(1)
@@ -3357,13 +4504,52 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 
 	#Python accessor
 
-	def py_SimulateInteractingCellLineage(self, np.ndarray timepoints, 
-										  list interface_list, 
-										  list initial_cell_states, 
-										  double global_sync_period, 
-										  np.ndarray global_species_inds, 
-										  double global_volume_param, 
+	def py_SimulateInteractingCellLineage(self, np.ndarray timepoints,
+										  list interface_list,
+										  list initial_cell_states,
+										  double global_sync_period,
+										  np.ndarray global_species_inds,
+										  double global_volume_param,
 										  double average_dist_threshold):
+		"""Simulate full lineages of interacting cell populations.
+
+		Lower-level than the module-level
+		`py_SimulateInteractingCellLineage`; prefer that function
+		unless reusing this simulator across many calls for
+		performance.
+
+		Warnings
+		--------
+		Interacting-lineage simulation is experimental/beta functionality.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to simulate over.
+		interface_list : list of LineageCSimInterface
+			One simulation interface per cell type.
+		initial_cell_states : list of list of LineageVolumeCellState
+			The starting cells, one list per interface.
+		global_sync_period : float
+			How often (in simulation time) cells resynchronize their
+			shared species with each other and the environment.
+		global_species_inds : numpy.ndarray
+			`global_species_inds[i, j]` is the species index of
+			global species `i` in interface `j`.
+		global_volume_param : float
+			The volume of the shared extracellular environment (0
+			for no explicit environment, in which case it's taken to
+			be the total cell volume).
+		average_dist_threshold : float
+			Redistribution threshold for each global species at
+			synchronization; see the module-level
+			`py_SimulateInteractingCellLineage`.
+
+		Returns
+		-------
+		list of Lineage
+			One full simulated lineage tree per cell type.
+		"""
 		self.set_c_timepoints(timepoints)
 		lineage_list = self.SimulateInteractingCellLineage(interface_list, 
 														   initial_cell_states, 
@@ -3546,6 +4732,47 @@ cdef class InteractingLineageSSASimulator(LineageSSASimulator):
 									 np.ndarray global_species_inds,
 									 double global_volume_param,
 									 double average_dist_threshold):
+		"""Simulate interacting cell populations, returning periodic snapshots.
+
+		Lower-level than the module-level
+		`py_PropagateInteractingCells`; prefer that function unless
+		reusing this simulator across many calls for performance.
+
+		Warnings
+		--------
+		Interacting-lineage simulation is experimental/beta functionality.
+
+		Parameters
+		----------
+		timepoints : numpy.ndarray
+			The times to simulate over.
+		interface_list : list of LineageCSimInterface
+			One simulation interface per cell type.
+		initial_cell_states : list of list of LineageVolumeCellState
+			The starting cells, one list per interface.
+		sample_times : numpy.ndarray
+			Times at which to sample the population; must be a
+			subset of `timepoints`.
+		global_sync_period : float
+			How often (in simulation time) cells resynchronize their
+			shared species with each other and the environment.
+		global_species_inds : numpy.ndarray
+			`global_species_inds[i, j]` is the species index of
+			global species `i` in interface `j`.
+		global_volume_param : float
+			The volume of the shared extracellular environment (0
+			for no explicit environment, in which case it's taken to
+			be the total cell volume).
+		average_dist_threshold : float
+			Redistribution threshold for each global species at
+			synchronization; see the module-level
+			`py_PropagateInteractingCells`.
+
+		Returns
+		-------
+		list
+			One entry per cell type, per sample time.
+		"""
 		self.set_c_timepoints(timepoints)
 		cell_sample_list =  self.PropagateInteractingCells(interface_list,
 										initial_cell_states,
@@ -3563,6 +4790,60 @@ def py_set_up_InteractingLineage(global_species = [], interface_list = [],
 								global_species_inds = None,
 								global_volume_simulator = "stochastic",
 								global_volume_model = None, safe = False):
+	"""Build the interfaces/simulator shared by the interacting-lineage functions.
+
+	Internal helper used by `py_PropagateInteractingCells` and
+	`py_SimulateInteractingCellLineage` to normalize their arguments;
+	not usually called directly.
+
+	Parameters
+	----------
+	global_species : list of str, default []
+		Species shared between cells via the extracellular
+		environment.
+	interface_list : list of LineageCSimInterface, default []
+		One simulation interface per cell type. Exactly one of
+		`interface_list` or `model_list` must be given.
+	model_list : list of LineageModel, default []
+		One model per cell type, used to build `interface_list`.
+		Exactly one of `interface_list` or `model_list` must be
+		given.
+	initial_cell_states : list, default []
+		Either one `LineageVolumeCellState` list per interface, or
+		(when its length matches `interface_list`) a list of ints
+		giving how many copies of each interface's initial state to
+		create.
+	t0 : float, default 0
+		The initial simulation time, used when creating default
+		initial cell states.
+	simulator : InteractingLineageSSASimulator, optional
+		The simulator to use. Defaults to a new
+		`InteractingLineageSSASimulator`.
+	global_species_inds : numpy.ndarray, optional
+		Precomputed mapping where `global_species_inds[i, j]` is the
+		species index of global species `i` in interface `j`.
+		Required when using `interface_list` instead of `model_list`.
+	global_volume_simulator : str, default "stochastic"
+		Simulator type for the optional shared-environment CRN given
+		by `global_volume_model`: ``'stochastic'`` or
+		``'deterministic'``.
+	global_volume_model : Model, optional
+		A `~bioscrape.types.Model` describing reactions in the
+		shared extracellular environment (e.g. degradation of a
+		secreted signal). If not given, global species amounts are
+		just tracked as totals, with no extracellular reactions.
+	safe : bool, default False
+		If True and `interface_list` is not given, build
+		`SafeLineageCSimInterface` instead of `LineageCSimInterface`
+		for each model in `model_list`.
+
+	Returns
+	-------
+	interface_list : list of LineageCSimInterface
+	simulator : InteractingLineageSSASimulator
+	initial_cell_states : list
+	global_species_inds : numpy.ndarray
+	"""
 	#Set up main simulator if needed
 	if simulator == None:
 		simulator = InteractingLineageSSASimulator()
@@ -3651,7 +4932,6 @@ def py_set_up_InteractingLineage(global_species = [], interface_list = [],
 
 	return interface_list, simulator, initial_cell_states, global_species_inds
 
-#Auxilary Python Function
 def py_PropagateInteractingCells(timepoints, global_sync_period,
 								 sample_times = 1, simulator = None,
 								 global_volume_simulator = "stochastic",
@@ -3662,6 +4942,88 @@ def py_PropagateInteractingCells(timepoints, global_sync_period,
 								 initial_cell_states = None,
 								 return_dataframes = False,
 								 return_sample_times = True, safe = False):
+	"""Simulate interacting cell populations, returning periodic snapshots.
+
+	Like `py_PropagateCells`, but for one or more cell types that
+	exchange `global_species` through a shared extracellular
+	environment, resynchronized every `global_sync_period`.
+
+	Warnings
+	--------
+	Interacting-lineage simulation is experimental/beta functionality.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to simulate over.
+	global_sync_period : float
+		How often (in simulation time) cells resynchronize their
+		shared `global_species` with each other and the environment.
+	sample_times : int or array-like, default 1
+		Times at which to sample the population. An int gives that
+		many evenly-spaced sample points ending at `timepoints[-1]`.
+	simulator : InteractingLineageSSASimulator, optional
+		The simulator to use. Defaults to a new
+		`InteractingLineageSSASimulator`.
+	global_volume_simulator : str, default "stochastic"
+		Simulator type for the optional shared-environment CRN given
+		by `global_volume_model`: ``'stochastic'`` or
+		``'deterministic'``.
+	global_volume_model : Model, optional
+		A `~bioscrape.types.Model` describing reactions in the
+		shared extracellular environment. If not given, global
+		species amounts are just tracked as totals.
+	global_volume : float, default 0
+		The volume of the shared extracellular environment.
+	global_species : list of str, optional
+		Species shared between cells via the extracellular
+		environment.
+	global_species_inds : numpy.ndarray, optional
+		Precomputed mapping where `global_species_inds[i, j]` is the
+		species index of global species `i` in interface `j`.
+		Required when using `interface_list` instead of `model_list`.
+	average_dist_threshold : float, default 1.0
+		Redistribution threshold for each global species at
+		synchronization: if the expected count per cell (scaled by
+		the ratio of total cell volume to `global_volume`) exceeds
+		this threshold, the species is redistributed
+		deterministically by its average; otherwise it's
+		redistributed stochastically (multinomially), to preserve
+		discreteness at low copy numbers.
+	interface_list : list of LineageCSimInterface, optional
+		One simulation interface per cell type. Exactly one of
+		`interface_list` or `model_list` must be given.
+	model_list : list of LineageModel, optional
+		One model per cell type, used to build `interface_list`.
+		Exactly one of `interface_list` or `model_list` must be
+		given.
+	initial_cell_states : list, optional
+		Either one `LineageVolumeCellState` list per interface, or
+		(when its length matches `interface_list`) a list of ints
+		giving how many copies of each interface's initial state to
+		create. Defaults to one cell per interface.
+	return_dataframes : bool, default False
+		If True (and pandas is installed), return each sample as a
+		`pandas.DataFrame`. If False, return each sample as a list
+		of `LineageVolumeCellState`.
+	return_sample_times : bool, default True
+		If True, also return the actual `sample_times` used.
+	safe : bool, default False
+		If True and `interface_list` is not given, build
+		`SafeLineageCSimInterface` instead of `LineageCSimInterface`
+		for each model in `model_list`.
+
+	Returns
+	-------
+	samples : list
+		One entry per cell type, per sample time.
+	sample_times : numpy.ndarray
+		Only returned if `return_sample_times` is True.
+	global_results : pandas.DataFrame or numpy.ndarray
+		The shared environment's species over time.
+	simulator : InteractingLineageSSASimulator
+		The simulator used, which can be reused for further calls.
+	"""
 	if global_species is None:
 		global_species = []
 	if interface_list is None:
@@ -3721,7 +5083,83 @@ def py_SimulateInteractingCellLineage(timepoints, global_sync_period,
 	simulator = None, global_volume_simulator = "stochastic", global_volume_model = None,
 	global_volume = 0, global_species = [], global_species_inds = None, average_dist_threshold = 1.0,
 	interface_list = [], model_list = [], initial_cell_states = [], return_dataframes = False, safe = False):
+	"""Simulate full lineages of interacting cell populations.
 
+	Like `py_SimulateCellLineage`, but for one or more cell types
+	that exchange `global_species` through a shared extracellular
+	environment, resynchronized every `global_sync_period`. The
+	entire time trajectory of every cell is kept (unlike
+	`py_PropagateInteractingCells`, which only keeps periodic
+	snapshots).
+
+	Warnings
+	--------
+	Interacting-lineage simulation is experimental/beta functionality.
+
+	Parameters
+	----------
+	timepoints : numpy.ndarray
+		The times to simulate over.
+	global_sync_period : float
+		How often (in simulation time) cells resynchronize their
+		shared `global_species` with each other and the environment.
+	simulator : InteractingLineageSSASimulator, optional
+		The simulator to use. Defaults to a new
+		`InteractingLineageSSASimulator`.
+	global_volume_simulator : str, default "stochastic"
+		Simulator type for the optional shared-environment CRN given
+		by `global_volume_model`: ``'stochastic'`` or
+		``'deterministic'``.
+	global_volume_model : Model, optional
+		A `~bioscrape.types.Model` describing reactions in the
+		shared extracellular environment. If not given, global
+		species amounts are just tracked as totals.
+	global_volume : float, default 0
+		The volume of the shared extracellular environment.
+	global_species : list of str, default []
+		Species shared between cells via the extracellular
+		environment.
+	global_species_inds : numpy.ndarray, optional
+		Precomputed mapping where `global_species_inds[i, j]` is the
+		species index of global species `i` in interface `j`.
+		Required when using `interface_list` instead of `model_list`.
+	average_dist_threshold : float, default 1.0
+		Redistribution threshold for each global species at
+		synchronization: if the expected count per cell (scaled by
+		the ratio of total cell volume to `global_volume`) exceeds
+		this threshold, the species is redistributed
+		deterministically by its average; otherwise it's
+		redistributed stochastically (multinomially), to preserve
+		discreteness at low copy numbers.
+	interface_list : list of LineageCSimInterface, default []
+		One simulation interface per cell type. Exactly one of
+		`interface_list` or `model_list` must be given.
+	model_list : list of LineageModel, default []
+		One model per cell type, used to build `interface_list`.
+		Exactly one of `interface_list` or `model_list` must be
+		given.
+	initial_cell_states : list, default []
+		Either one `LineageVolumeCellState` list per interface, or
+		(when its length matches `interface_list`) a list of ints
+		giving how many copies of each interface's initial state to
+		create. Defaults to one cell per interface.
+	return_dataframes : bool, default False
+		If True (and pandas is installed), return `global_results`
+		as a `pandas.DataFrame`.
+	safe : bool, default False
+		If True and `interface_list` is not given, build
+		`SafeLineageCSimInterface` instead of `LineageCSimInterface`
+		for each model in `model_list`.
+
+	Returns
+	-------
+	lineage_list : list of Lineage
+		One full simulated lineage tree per cell type.
+	global_results : pandas.DataFrame or numpy.ndarray
+		The shared environment's species over time.
+	simulator : InteractingLineageSSASimulator
+		The simulator used, which can be reused for further calls.
+	"""
 	interface_list, simulator, initial_cell_states, global_species_inds = py_set_up_InteractingLineage(global_species = global_species, interface_list = interface_list, model_list = model_list, initial_cell_states = initial_cell_states,
 		simulator = simulator, global_species_inds = global_species_inds, global_volume_simulator = global_volume_simulator, global_volume_model = global_volume_model, t0 = timepoints[0], safe = safe)
 

--- a/lineage/lineage.pyx
+++ b/lineage/lineage.pyx
@@ -3660,6 +3660,13 @@ def py_SimulateCellLineage(timepoints, initial_cell_states = [], initial_cell_co
 def py_SimulateSingleCell(timepoints, Model = None, interface = None, initial_cell_state = None, return_dataframes = True, safe = False):
 	"""Simulate one cell until it divides, dies, or time runs out.
 
+	Unlike `py_SimulateCellLineage`/`py_PropagateCells`/
+	`py_SingleCellLineage`, which track a population or continue
+	past divisions, this stops at the first division or death event
+	(or the final timepoint), returning just that one cell's
+	trajectory up to that point -- the single-cell building block
+	the other lineage functions are built on.
+
 	Parameters
 	----------
 	timepoints : numpy.ndarray


### PR DESCRIPTION
This PR updates (and often creates) docstrings for all public functions and methods, using numpydoc conventions.  Here is a detailed list of changes (see individual commit messages if you want even more detailed):

- Converts every public docstring across `bioscrape/analysis.py`, `pid_interfaces.py`, `inference.pyx`, `inference_setup.py`, `types.pyx`, `simulator.pyx`, `sbmlutil.py`, and `lineage/lineage.pyx` (~90 classes/functions) from three previously-mixed, incompatible styles (ad hoc, Google-style, bare prose) to a single consistent [[numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)](https://numpydoc.readthedocs.io/en/latest/format.html) convention, documented in `contributing.md`'s new "Docstrings" subsection (with `CLAUDE.md` pointing to it).
- Includes a follow-up manual-review pass that caught and fixed a number of real docstring bugs surfaced by close reading, not just a style conversion:
  - Fixed docstrings that referenced instance attributes with a bare `` `x` `` as if they were parameters of the enclosing method (reads as though the method accepts an argument it doesn't) — reworded to `` `self.x` `` throughout `inference_setup.py` and `pid_interfaces.py`.
  - Promoted parameters that are actually consumed via `kwargs.get()` but were only described inside a generic `**kwargs` blurb to their own documented `Parameters` entries (`pid_interfaces.py`, `analysis.py`).
  - Removed a "returns `inf` with a warning if negative" claim from `gaussian_prior`/`log_gaussian_prior`'s docstrings after confirming that branch is mathematically unreachable.
  - Added the `"""See class docstring."""` stub to every `__init__` that was missing one (56/56 now consistent), guarding against Sphinx/`help()` silently inheriting a parent class's constructor docs.
  - Fixed dict keys documented with single backticks (implying real Python objects) instead of single-quoted string literals, throughout `types.pyx` and `lineage.pyx`.
  - Simplified double-backtick-wrapped formulas to plain text, matching the convention already used elsewhere in the codebase.
  - Two real (non-docstring) bugs found and fixed in passing: a duplicate, dead-code `Model.py_initialize` definition that was silently shadowing the documented one; and a Sphinx `.. deprecated::` directive missing its version argument, which was rendering as the nonsensical "Deprecated since version Bioscrape".
  - Documented previously-invisible `**keywords` parameters in `Propensity.get_species_and_parameters`/`Delay.get_species_and_parameters`.
  - Expanded one-line descriptions for top-level user entry points (`py_simulate_model`, `py_inference`, the `bioscrape.simulator` classes, `py_SimulateSingleCell`) that had no explanation of mechanism/algorithm, sourced from the parallel `documentation-09Jul2026-v2` branch's user manual.
  - Added this codebase's first numpydoc `See Also` sections, on the four simulator interface/base classes, pointing to their concrete implementations.

Changes were co-authored by Claude Sonnet 5 but reviewed in multiple passes by the author.  There is a (very simple) CLAUDE.md file included, pointing to a description of the docstring standards in `contributing.md`.

In the course of documenting these functions, several additional code bugs were identified beyond the `Model.py_initialize` bug identified above.  Since those additional bugs are not related to docstrings, they are captured in a separate PR (with a more elaborate CLAUDE.md file to guide revisions).