### PR TITLE
Add sensitivity analysis, likelihood/prior/data-type docs, and simulator examples to the user guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,18 @@ extensions = [
     "nbsphinx_link",
     "recommonmark",
     "numpydoc",
+    "matplotlib.sphinxext.plot_directive",
 ]
+
+# matplotlib.sphinxext.plot_directive: run the code in `.. plot::` blocks
+# at build time and embed the resulting figure.  Ships with matplotlib
+# itself (already a bioscrape dependency), so no extra package is
+# required.  Used in user_guide/sensitivity.rst for a worked example
+# with a live-generated plot.
+plot_include_source = True
+plot_html_show_source_link = False
+plot_html_show_formats = False
+plot_formats = [("png", 110)]
 
 source_suffix = [".rst"]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ to estimate model parameters from experimental data.
    user_guide/simulators
    user_guide/propensities
    user_guide/delays
+   user_guide/sensitivity
    user_guide/parameter_inference
    user_guide/sbml_support
    user_guide/lineage_package

--- a/docs/user_guide/lineage_package.rst
+++ b/docs/user_guide/lineage_package.rst
@@ -57,4 +57,24 @@ Volume Splitters
 
 As cells grow and divide, their internal species are re-partitioned
 according to VolumeSplitter objects which are associated with every
-DivisionRule and DivisionEvent.
+DivisionRule and DivisionEvent. Each species (and the volume itself)
+can be partitioned in one of several ways:
+
+-  'binomial' -- each molecule independently goes to one daughter with
+   probability roughly one half (the default).
+-  'perfect' -- molecules are divided in proportion to the daughter
+   volumes, up to rounding.
+-  'duplicate' -- each daughter receives a full copy of the parent's
+   count.
+-  a user-supplied custom partitioning function.
+
+The mode can be chosen per species (with a 'default' for unlisted
+species and a separate setting for the volume), and the
+``partition_noise`` option adds extra randomness to the binomial split
+fraction.
+
+In a volume-based simulation a species value is a molecule count, and
+the corresponding concentration is that count divided by the cell
+volume. A common convention when interpreting such results is to
+treat one molecule per characteristic *E. coli* cell volume as
+roughly 1 nM.

--- a/docs/user_guide/overview.rst
+++ b/docs/user_guide/overview.rst
@@ -4,7 +4,7 @@ Overview
 Bioscrape has three primary features related to modeling, analysis, simulations, and parameter inference:
 
 1. Models can be :doc:`imported from SBML files <sbml_support>`
-   and modified using the internal API. Other than changes to species, parameters, and reactions, users can also add :doc:`delays <delays>` to reactions and add assignment rules. Bioscrape provides sensitivity analysis tools for these models to determine how sensitive the model is to local changes in parameters.
+   and modified using the internal API. Other than changes to species, parameters, and reactions, users can also add :doc:`delays <delays>` to reactions and add assignment rules. Bioscrape provides :doc:`sensitivity analysis tools <sensitivity>` for these models to determine how sensitive the model is to local changes in parameters.
 
 2. Bioscrape includes :doc:`fast deterministic and stochastic simulators <simulators>` written
    in `Cython <https://cython.org/>`__ that can be used to simulate the

--- a/docs/user_guide/parameter_inference.rst
+++ b/docs/user_guide/parameter_inference.rst
@@ -78,6 +78,22 @@ the parameter ``k1`` as gaussian(0,10) but with only positive values.
 Example: ``{'k1': ['exponential', 5]}`` sets the prior for the parameter
 ``k1`` as exponential(5).
 
+-  Gamma: To give a gamma prior to a parameter use, prior-type-key:
+   ``"gamma"``. The ``prior_parameter1`` is the shape parameter
+   (alpha) and the ``prior_parameter2`` is the rate parameter (beta)
+   of the gamma distribution.
+
+Example: ``{'k1': ['gamma', 2, 3]}`` sets the prior for the parameter
+``k1`` as gamma(alpha=2, beta=3).
+
+-  Beta: To give a beta prior to a parameter use, prior-type-key:
+   ``"beta"``. The ``prior_parameter1`` and ``prior_parameter2`` are
+   the alpha and beta shape parameters of the beta distribution. The
+   parameter value is expected to lie in ``[0, 1]``.
+
+Example: ``{'k1': ['beta', 2, 3]}`` sets the prior for the parameter
+``k1`` as beta(alpha=2, beta=3).
+
 -  Log Uniform: To give a log uniform prior to a parameter use,
    prior-type-key: ``"log-uniform"``. The ``prior_parameter1`` is the
    lower bound of the log uniform probability distribution and the

--- a/docs/user_guide/parameter_inference.rst
+++ b/docs/user_guide/parameter_inference.rst
@@ -133,6 +133,35 @@ parameter ``k1`` as a custom function which is the callable
 For an example on how to run custom prior distribution, check out the
 prior distribution notebook in ``inference examples`` directory.
 
+Data Types
+~~~~~~~~~~
+
+Experimental data passed to inference is held in one of the
+`~bioscrape.inference.Data` subclasses, each corresponding to a
+different kind of measurement:
+
+-  `~bioscrape.inference.BulkData`: a single output measured for a
+   whole culture over time (e.g. total fluorescence or optical
+   density from a plate reader), where the measured value is
+   effectively summed or averaged over all the cells. This is a bulk
+   time series.
+-  `~bioscrape.inference.FlowData`: a *distribution* of single-cell
+   outputs at one or more time points, with individual cells not
+   tracked from one time point to the next (e.g. flow cytometry or
+   mRNA FISH). This is a population snapshot.
+-  `~bioscrape.inference.StochasticTrajectories`: one or more
+   individual cells tracked over time (e.g. time-lapse microscopy).
+   This is a single-cell time series.
+
+When using `~bioscrape.inference.py_inference`, the ``sim_type``
+argument selects the data type and likelihood together:
+``sim_type="deterministic"`` (the default) uses
+`~bioscrape.inference.BulkData`, and ``sim_type="stochastic"`` uses
+`~bioscrape.inference.StochasticTrajectories`.
+`~bioscrape.inference.FlowData` is used by constructing the
+likelihood object directly rather than through
+`~bioscrape.inference.py_inference`.
+
 Likelihood options
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/parameter_inference.rst
+++ b/docs/user_guide/parameter_inference.rst
@@ -120,6 +120,25 @@ prior distribution notebook in ``inference examples`` directory.
 Likelihood options
 ~~~~~~~~~~~~~~~~~~
 
+Each type of experimental data is paired with a likelihood class that
+computes the log-likelihood of a parameter set given that data:
+
+-  `~bioscrape.inference.DeterministicLikelihood`: compares a single
+   deterministic (ODE) simulation against bulk time-series data. Used
+   when ``sim_type`` is ``"deterministic"`` (the default).
+-  `~bioscrape.inference.StochasticTrajectoriesLikelihood`: runs
+   several stochastic simulations (see the ``N_simulations`` option)
+   and scores how close the simulated single-cell trajectories are to
+   the measured ones. Used when ``sim_type`` is ``"stochastic"``.
+-  `~bioscrape.inference.StochasticTrajectoryMomentLikelihood`: a
+   variant of the previous likelihood that compares the *moments* of
+   the trajectories -- their means with ``Moments=1``, or means and
+   second moments with ``Moments=2`` -- rather than individual
+   trajectories.
+-  `~bioscrape.inference.StochasticStatesLikelihood`: compares the
+   *distribution* of simulated states to a measured distribution at
+   each time point, for population-snapshot data.
+
 MCMC parameter set-up options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/sensitivity.rst
+++ b/docs/user_guide/sensitivity.rst
@@ -1,0 +1,125 @@
+.. currentmodule:: bioscrape.analysis
+
+Sensitivity Analysis
+=====================
+
+Sensitivity analysis answers a simple question: if a parameter's value
+changed slightly, how much would the model's trajectories change?
+This is useful on its own, for finding which parameters most strongly
+drive a species' behavior over time, but it also has a more practical
+role as a precursor to :doc:`parameter inference <parameter_inference>`.
+Not every parameter that appears in a model can actually be estimated
+from a given measurement -- if a species' trajectory barely changes as
+a parameter is varied, no amount of data on that trajectory will pin
+the parameter down, and running expensive MCMC sampling to try is
+wasted effort. Checking which parameters a measured output is
+sensitive to, before fitting, tells you which parameters are worth
+estimating from that data and which should be fixed or determined
+separately.
+
+Bioscrape can compute the local sensitivity of a model's trajectories
+to its parameters, i.e. the coefficients
+:math:`s_{ij} = \partial x_i / \partial p_j` at each simulated time
+point, where :math:`x_i` is a state (species) and :math:`p_j` is a
+parameter.
+
+Computing Sensitivities
+-------------------------
+
+The user-facing entry point is `~bioscrape.analysis.py_sensitivity_analysis`::
+
+    from bioscrape.analysis import py_sensitivity_analysis
+    import numpy as np
+
+    timepoints = np.linspace(0, 100, 100)
+    S = py_sensitivity_analysis(M, timepoints, normalize=False)
+
+When ``normalize=True``, each coefficient is divided by :math:`x_i /
+p_j`, giving a dimensionless relative sensitivity.
+
+Two lower-level helpers are also available for computing sensitivities
+at a single point rather than along a full trajectory:
+
+- `~bioscrape.analysis.py_get_jacobian`: the Jacobian :math:`\partial
+  f/\partial x` of the model's right-hand side at a given state
+- `~bioscrape.analysis.py_get_sensitivity_to_parameter`: the
+  sensitivity :math:`\partial f/\partial p` to a single named
+  parameter at a given state
+
+Both `~py_sensitivity_analysis` and the two helper functions are
+implemented on top of `~bioscrape.analysis.SensitivityAnalysis`, a
+`~bioscrape.types.Model` subclass that adds finite-difference
+computation of Jacobians and parameter sensitivities using a
+deterministic simulation of the model.
+
+Checking Sensitivities Against an Analytical Steady State
+------------------------------------------------------------
+
+For a simple enough model, the computed sensitivities can be checked
+directly against an analytical result. For the birth-death reaction
+below, ``X`` reaches a deterministic steady state of ``k_prod /
+k_deg``, and its steady-state sensitivities to the two rate parameters
+have simple closed forms: :math:`\partial X/\partial k_{prod} =
+1/k_{deg}` and :math:`\partial X/\partial k_{deg} =
+-k_{prod}/k_{deg}^2`. Running `~py_sensitivity_analysis` and letting
+the trajectory settle shows the computed sensitivities converging to
+exactly these values:
+
+.. plot::
+
+    from bioscrape.types import Model
+    from bioscrape.analysis import py_sensitivity_analysis
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    M = Model()
+    M.create_reaction(reactants=[], products=['X'],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_prod'})
+    M.create_reaction(reactants=['X'], products=[],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_deg'})
+    k_prod, k_deg = 10.0, 0.5
+    M.set_parameter('k_prod', k_prod)
+    M.set_parameter('k_deg', k_deg)
+    M.set_species({'X': 0})
+
+    timepoints = np.linspace(0, 40, 200)
+    # S has shape (len(timepoints), len(parameters), len(species)); the
+    # parameter order matches M.get_parameter_dictionary(), here
+    # [k_prod, k_deg], and there is a single species, X.
+    S = py_sensitivity_analysis(M, timepoints, normalize=False)
+
+    plt.plot(timepoints, S[:, 0, 0], label=r'$\partial X/\partial k_{prod}$')
+    plt.axhline(1 / k_deg, color='0.5', ls='--')
+    plt.plot(timepoints, S[:, 1, 0], label=r'$\partial X/\partial k_{deg}$')
+    plt.axhline(-k_prod / k_deg**2, color='0.5', ls='--')
+    plt.xlabel('Time')
+    plt.ylabel('Sensitivity')
+    plt.legend()
+
+For a multi-species example -- the sensitivities of a genetic toggle
+switch's four species to all nine of its parameters -- see the
+`Sensitivity Analysis Using Bioscrape
+<https://github.com/biocircuits/bioscrape/blob/master/examples/Sensitivity%20Analysis%20using%20Bioscrape.ipynb>`__
+notebook.
+
+Real-world example
+--------------------
+
+The by-parts strategy sketched above -- using sensitivity analysis to
+find which parameters a measurement can identify, fitting those,
+fixing them, and repeating for the next measured output -- is exactly
+how bioscrape's sensitivity and inference tools were used together in
+[Pan+23d]_ to characterize a Bxb1 integrase/excisionase DNA
+recombination circuit in cell-free extract: sensitivity analysis on
+the fluorescence data first identified the small subset of parameters
+each reporter's trajectory could actually constrain, and Bayesian
+inference (:doc:`parameter_inference`) was then run on only those
+parameters, one measured species at a time.
+
+.. [Pan+23d] Pandey A, Rodriguez ML, Poole W, Murray RM (2023)
+   Characterization of integrase and excisionase activity in a
+   cell-free protein expression system using a modeling and analysis
+   pipeline. *ACS Synthetic Biology* 12(2):511-523.
+   https://doi.org/10.1021/acssynbio.2c00534

--- a/docs/user_guide/simulators.rst
+++ b/docs/user_guide/simulators.rst
@@ -1,33 +1,258 @@
 Simulators
 ==========
 
-For examples of how to actually do simulations, check `this
-notebook <https://github.com/biocircuits/bioscrape/blob/master/examples/Basic%20Examples%20-%20START%20HERE.ipynb>`__.
-Briefly, different simulation modes can be easily toggled using the
-following keywords in the ``py_SimulateModel(timepoints, Model = ...)``
-wrapper:
+The simplest way to simulate a model is the
+`~bioscrape.simulator.py_simulate_model` convenience function, which
+selects and configures the appropriate simulator based on its keyword
+arguments::
+
+    from bioscrape.simulator import py_simulate_model
+    import numpy as np
+
+    timepoints = np.linspace(0, 256, 100)
+    result = py_simulate_model(timepoints, Model=M, stochastic=True)
+
+By default `~bioscrape.simulator.py_simulate_model` returns a pandas
+``DataFrame`` indexed by species and parameter name; pass
+``return_dataframe=False`` to get the underlying result object
+instead. Different simulation modes can be toggled using its keyword
+arguments:
 
 ``stochastic = True / False`` Switches between Stochastic (SSA) and
-determinstic (ODE simulation). Defaults to deterministic.
+deterministic (ODE) simulation. Defaults to deterministic.
 
 ``delay = False / True`` adds delay to stochastic simulation.
 Deterministic simulation with delay is not supported. Using delay
 requires instantiating reactions with :doc:`delay <delays>`. Defaults
 to False.
 
-``volume = False / True`` adds volume parameter for SSA simulations. For
-single cell simulation with volume, use the (lineages
-package)[Lineage-Package]
+``volume = False / True`` adds volume parameter for SSA simulations.
+For single cell simulation with volume, use the :doc:`Bioscrape
+Lineages <lineage_package>` package.
 
+For examples of how to actually do simulations, check `this
+notebook <https://github.com/biocircuits/bioscrape/blob/master/examples/Basic%20Examples%20-%20START%20HERE.ipynb>`__.
 Advanced users and developers can check out `this
 notebook <https://github.com/biocircuits/bioscrape/blob/master/examples/Advanced%20Examples%20-%20Direct%20Simulator%20Instantiation.ipynb>`__
 for more details on running simulations more directly.
 
+Deterministic vs. Stochastic Simulation
+----------------------------------------
+
+The two agree on average but not trajectory-by-trajectory: for a
+birth-death model where a species ``X`` is produced at a constant
+rate and degrades in a first-order reaction, a single stochastic
+trajectory fluctuates around the deterministic solution rather than
+following it exactly, with fluctuations that are largest (relative to
+the mean) when molecule counts are small:
+
+.. plot::
+
+    from bioscrape.types import Model
+    from bioscrape.simulator import py_simulate_model
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import bioscrape.random
+    bioscrape.random.py_seed_random(0)
+
+    M = Model()
+    M.create_reaction(reactants=[], products=['X'],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_prod'})
+    M.create_reaction(reactants=['X'], products=[],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_deg'})
+    M.set_parameter('k_prod', 10.0)
+    M.set_parameter('k_deg', 0.5)
+    M.set_species({'X': 0})
+
+    timepoints = np.linspace(0, 40, 200)
+    det = py_simulate_model(timepoints, Model=M, stochastic=False)
+    sto = py_simulate_model(timepoints, Model=M, stochastic=True)
+
+    plt.plot(timepoints, sto['X'], color='0.6', label='Stochastic (SSA)')
+    plt.plot(timepoints, det['X'], lw=2, label='Deterministic (ODE)')
+    plt.xlabel('Time')
+    plt.ylabel('X')
+    plt.legend()
+
+Delayed Reactions
+------------------
+
+Delay changes the shape of the dynamics, not just their timing:
+without delay, a reaction's products can appear as soon as the
+reaction fires, but with delay, nothing changes until the first
+delayed products complete, after which the delayed trajectory
+resembles the undelayed one shifted forward in time. For a delayed
+transcription model (see :doc:`delays`) where mRNA appears a fixed
+time after each firing rather than immediately, comparing simulations
+of the same model with and without delay makes this visible directly:
+
+.. plot::
+
+    from bioscrape.types import Model
+    from bioscrape.simulator import py_simulate_model
+    import numpy as np
+    import matplotlib.pyplot as plt
+    import bioscrape.random
+
+    M = Model()
+    M.create_reaction(
+        reactants=[], products=[],
+        propensity_type='massaction', propensity_param_dict={'k': 'beta'},
+        delay_type='fixed', delay_reactants=[], delay_products=['mRNA'],
+        delay_param_dict={'delay': 'tx_delay'})
+    M.create_reaction(
+        reactants=['mRNA'], products=[],
+        propensity_type='massaction', propensity_param_dict={'k': 'delta'})
+    M.set_parameter('beta', 2)
+    M.set_parameter('delta', 0.2)
+    M.set_parameter('tx_delay', 10)
+    M.set_species({'mRNA': 0})
+
+    timepoints = np.linspace(0, 50, 200)
+
+    # Re-seeding before each run means both share the same sequence of
+    # reaction firings, isolating the effect of the delay itself.
+    bioscrape.random.py_seed_random(0)
+    no_delay = py_simulate_model(timepoints, Model=M, stochastic=True, delay=False)
+    bioscrape.random.py_seed_random(0)
+    with_delay = py_simulate_model(timepoints, Model=M, stochastic=True, delay=True)
+
+    plt.plot(timepoints, no_delay['mRNA'], label='No delay')
+    plt.plot(timepoints, with_delay['mRNA'], label='Fixed delay = 10')
+    plt.xlabel('Time')
+    plt.ylabel('mRNA')
+    plt.legend()
+
+Volume-Dependent Rates
+------------------------
+
+When a volume is present (``volume=True``), species are counts of
+molecules but the reaction rates depend on their *concentrations*, so
+bioscrape rescales the propensities by the current volume. This
+happens automatically; you write the same rate laws as in a
+volumeless simulation, and the following adjustments are applied
+under the hood:
+
+-  A *zeroth-order* (constitutive) mass-action rate scales with the
+   volume: a fixed concentration of product is made per unit time, so
+   the number of molecules produced grows with the cell.
+-  A *first-order* (unimolecular) mass-action rate is unchanged: it
+   depends only on the count of the single reactant.
+-  A *second-order* (bimolecular) mass-action rate scales as
+   ``1 / volume``: two molecules are less likely to find each other in
+   a larger volume.
+-  More generally, an n-th order mass-action rate scales as
+   ``1 / volume ** (n - 1)``.
+-  In a Hill propensity, the input species count is divided by the
+   volume, i.e. the rate is computed from the species' *concentration*
+   rather than its count, because it is the concentration that sets
+   the equilibrium binding (for example of a transcription factor to a
+   promoter).
+
+Because these conversions are automatic, a rate constant fit or chosen
+for a volumeless simulation may need to be re-scaled when the same
+model is simulated with a volume, and vice versa. Single-cell
+simulation with volume and cell division uses the :doc:`Bioscrape
+Lineages <lineage_package>` package.
+
+Checking a Stochastic Simulation
+-----------------------------------
+
+For a simple enough model, the stochastic simulator's output can be
+checked directly against a known analytical result, which is a useful
+way to build confidence in a new model or a modified reaction network.
+The birth-death model above is a textbook example: at steady state,
+its species count ``X`` follows a Poisson distribution with mean and
+variance both equal to ``k_prod / k_deg``. Simulating it stochastically
+for long enough, and comparing the distribution of ``X`` values (after
+discarding an initial transient) against that Poisson distribution,
+confirms that bioscrape's SSA implementation reproduces the expected
+statistics:
+
+.. plot::
+
+    from bioscrape.types import Model
+    from bioscrape.simulator import py_simulate_model
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from scipy.stats import poisson
+    import bioscrape.random
+    bioscrape.random.py_seed_random(0)
+
+    M = Model()
+    M.create_reaction(reactants=[], products=['X'],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_prod'})
+    M.create_reaction(reactants=['X'], products=[],
+                      propensity_type='massaction',
+                      propensity_param_dict={'k': 'k_deg'})
+    M.set_parameter('k_prod', 10.0)
+    M.set_parameter('k_deg', 0.5)
+    M.set_species({'X': 0})
+
+    timepoints = np.linspace(0, 2000, 20000)
+    result = py_simulate_model(timepoints, Model=M, stochastic=True)
+    X = result['X'].values
+
+    # Discard the transient before the distribution reaches steady state.
+    X_steady_state = X[timepoints > 200].astype(int)
+
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+
+    ax1.plot(timepoints[timepoints < 100], X[timepoints < 100])
+    ax1.set_xlabel('Time')
+    ax1.set_ylabel('X')
+    ax1.set_title('Stochastic trajectory')
+
+    counts = np.bincount(X_steady_state)
+    xs = np.arange(len(counts))
+    ax2.bar(xs, counts / counts.sum(), color='0.7', label='Empirical')
+    ax2.plot(xs, poisson.pmf(xs, mu=10.0 / 0.5), lw=2, label='Poisson(20)')
+    ax2.set_xlabel('X')
+    ax2.set_ylabel('Probability')
+    ax2.set_title('Steady-state distribution')
+    ax2.legend()
+
+    plt.tight_layout()
+
+`~bioscrape.simulator.SSAResult` provides some of this analysis
+directly, including `~bioscrape.simulator.SSAResult.py_first_moment`
+and `~bioscrape.simulator.SSAResult.py_correlations` for computing
+means and correlations from a simulated trajectory without the manual
+post-processing shown above. For a more complete worked example,
+including statistics of a multi-species model, see the *Fast
+Statistics for SSA Trajectories* notebook.
+
 Built-in Simulators
--------------------
+---------------------
 
 Simulations can be performed deterministically (without delay or cell
 division, i.e. regular deterministic ODE's for a system of reactions),
 or they can be performed stochastically with or without delay and with
 or without cell growth and division using the :doc:`Bioscrape
-Lineages <lineage_package>` package.
+Lineages <lineage_package>` package. The concrete simulator classes,
+selected automatically by `~bioscrape.simulator.py_simulate_model`
+based on its ``stochastic``/``delay``/``volume`` arguments, are:
+
+-  `~bioscrape.simulator.DeterministicSimulator`
+-  `~bioscrape.simulator.SSASimulator`
+-  `~bioscrape.simulator.DelaySSASimulator`
+-  `~bioscrape.simulator.VolumeSSASimulator`
+-  `~bioscrape.simulator.DelayVolumeSSASimulator`
+
+Simulation Interfaces
+------------------------
+
+`~bioscrape.simulator.CSimInterface` and its subclasses
+(`~bioscrape.simulator.ModelCSimInterface`,
+`~bioscrape.simulator.SafeModelCSimInterface`) adapt a model into the
+low-level form used internally by the simulators. Most users will not
+need to construct these directly --
+`~bioscrape.simulator.py_simulate_model` creates one automatically --
+but they can be reused across repeated simulations of the same model
+for performance (the ``Interface`` keyword argument), or replaced with
+a `~bioscrape.simulator.SafeModelCSimInterface` (via ``safe=True``) to
+get warnings about ill-conditioned situations such as negative
+propensities.


### PR DESCRIPTION
This PR builds on the branch used for PR #186. It should be merged *before* #186.

Adds narrative content to a few pages that were thin or missing entirely, drawing on a fuller documentation pass done in parallel on docstring_numpydoc-09Jul2026 (already merged into this branch's docstring content via d507bad).

Changes:
- New `user_guide/sensitivity.rst`: local sensitivity analysis, the three-function API, a live-rendered worked example checked against an analytical steady state, and a real-world case study.
- `user_guide/parameter_inference.rst`: filled in the empty "Likelihood options" section, added the missing gamma/beta priors, and added a "Data Types" section mapping `BulkData`/`FlowData`/`StochasticTrajectories` to their measurement types.
- `user_guide/lineage_package.rst`: documented the volume-splitter partitioning modes and the concentration convention for volume-based simulations.
- `user_guide/simulators.rst`: added live-rendered deterministic-vs-stochastic and delay-vs-no-delay comparison plots, the volume-dependent rate scaling rules, an analytical check against a Poisson steady state, and descriptions of the simulator/interface classes. Also fixed a stale `py_SimulateModel` reference and a broken Markdown-style link left over in the original text.
- `conf.py`: added matplotlib.sphinxext.plot_directive (+ its plot_* settings) to support the live-rendered examples above.

All new/changed documentation uses single-backtick cross-references (`~module.Name`) into the existing api/*.rst pages rather than plain code-literal mentions, so the new content links out to the reference manual.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>