### PR TITLE
Build bioscrape.lineage for the Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,15 +1,39 @@
 version: 2
 
+# Set the OS, Python version, and other tools you might need
+#
+# bioscrape's public API is implemented in Cython, so autodoc needs to
+# be able to `import bioscrape` -- unlike a pure-Python package, this
+# means the package itself must be built/installed (not just the
+# Sphinx toolchain) before the docs can be built.  That install is
+# done below via a `post_install` job rather than the declarative
+# `python.install` section, so that we can set the
+# BIOSCRAPE_BUILD_LINEAGE environment variable on that one command --
+# see the comment above the job for why.
 build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_install:
+      # A plain `pip install bioscrape` does NOT build the optional
+      # `bioscrape.lineage` extension (it's excluded from the default
+      # install because it isn't as well maintained as the rest of
+      # the package -- see setup.py). The docs reference
+      # bioscrape.lineage (docs/api/optional_lineage.rst,
+      # docs/user_guide/lineage_package.rst), though, so this build
+      # needs it. Setting BIOSCRAPE_BUILD_LINEAGE=1 tells setup.py to
+      # build the lineage extension for this install only -- it has
+      # no effect on what PyPI users get from a normal `pip install
+      # bioscrape`.
+      - BIOSCRAPE_BUILD_LINEAGE=1 pip install .
 
 sphinx:
   configuration: docs/conf.py
 
+# Install the Sphinx toolchain declaratively; the bioscrape package
+# itself is installed above in build.jobs.post_install instead (see
+# comment there).
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,16 @@ try:
         install_lineage = True
         sys.argv.remove("lineage")
 
+    # Also allow the lineage extension to be requested via an
+    # environment variable, since `pip install .` invokes this file
+    # through a build backend rather than as `python setup.py install
+    # lineage`, so sys.argv never contains "lineage" in that case.
+    # This is used by the Read the Docs build (see .readthedocs.yaml)
+    # so that bioscrape.lineage can be documented, without changing
+    # what a normal `pip install bioscrape` builds.
+    if os.environ.get("BIOSCRAPE_BUILD_LINEAGE") == "1":
+        install_lineage = True
+
     # elif "bioscrape" not in sys.argv:
     #     install_lineage = False
 


### PR DESCRIPTION
docs/api/optional_lineage.rst documents bioscrape.lineage via
automodule, but a plain `pip install .` -- what .readthedocs.yaml
does -- never builds that extension: setup.py only builds it when
the literal string "lineage" is a positional sys.argv token (i.e.
`python setup.py install lineage`), and pip's build-backend
invocation never puts that there. So on Read the Docs, `import
bioscrape.lineage` fails and the automodule directive breaks the
build with an ImportError, rather than just omitting content.

setup.py now also checks the `BIOSCRAPE_BUILD_LINEAGE` environment
variable as a second trigger for building the lineage extension,
and .readthedocs.yaml sets it on a `build.jobs.post_install` step
(replacing the declarative `python.install` package step, since
that section can't set environment variables on the install
command). This only affects the docs build -- a normal `pip install
bioscrape` is unaffected, since nothing sets that variable there.

This needs to be verified with a real RTD build/PR preview before
merging.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>